### PR TITLE
Improved Array2 structure

### DIFF
--- a/basis/ARRAY2.sig
+++ b/basis/ARRAY2.sig
@@ -1,176 +1,152 @@
-signature ARRAY2 =
-  sig
-    eqtype 'a array
-    type 'a region = {
-                       base : 'a array,
-                       row : int,
-                       col : int,
-                       nrows : int option,
-                       ncols : int option
-                     }
-    datatype traversal = RowMajor | ColMajor
+(**
 
-    val array    : int * int * 'a -> 'a array
-    val fromList : 'a list list -> 'a array
-    val tabulate : traversal 
-                   -> int * int * (int * int -> 'a) -> 'a array
+The ARRAY2 signature is a polymorphic interface to mutable
+2-dimensional arrays. Two arrays are equal only if they are the same
+array, i.e., created by the same call to a primitive array constructor
+such as array, fromList, etc.; otherwise they are not equal. This also
+holds for arrays of zero length.
 
-    val sub : 'a array * int * int -> 'a
-    val update : 'a array * int * int * 'a -> unit
+The elements of 2-dimensional arrays are indexed by pair of integers
+(i,j) where i gives the row index, and i gives the column index. As
+usual, indices start at 0, with increasing indices going from left to
+right and, in the case of rows, from top to bottom.
 
-    val dimensions : 'a array -> int * int
-    val nCols      : 'a array -> int
-    val nRows      : 'a array -> int
+*)
 
-    val row    : 'a array * int -> 'a Vector.vector
-    val column : 'a array * int -> 'a Vector.vector
+signature ARRAY2 = sig
+  eqtype 'a array
+  type 'a region = {base : 'a array,
+                    row : int,
+                    col : int,
+                    nrows : int option,
+                    ncols : int option}
 
-    val copy : {
-                   src : 'a region,
-                   dst : 'a array,
-                   dst_row : int,
-                   dst_col : int
-                 } -> unit
+  datatype traversal = RowMajor | ColMajor
 
-    val appi : traversal
-                 -> (int * int * 'a -> unit)
-                   -> 'a region -> unit
-    val app  : traversal -> ('a -> unit) -> 'a array -> unit
-    val foldi : traversal
-                  -> (int * int * 'a * 'b -> 'b)
-                    -> 'b -> 'a region -> 'b
-    val fold  : traversal
-                  -> ('a * 'b -> 'b) -> 'b -> 'a array -> 'b
-    val modifyi : traversal
-                    -> (int * int * 'a -> 'a)
-                      -> 'a region -> unit
-    val modify  : traversal -> ('a -> 'a) -> 'a array -> unit 
+  val array    : int * int * 'a -> 'a array
+  val fromList : 'a list list -> 'a array
+  val tabulate : traversal -> int * int * (int * int -> 'a) -> 'a array
+
+  val sub : 'a array * int * int -> 'a
+  val update : 'a array * int * int * 'a -> unit
+
+  val dimensions : 'a array -> int * int
+  val nCols      : 'a array -> int
+  val nRows      : 'a array -> int
+
+  val row    : 'a array * int -> 'a Vector.vector
+  val column : 'a array * int -> 'a Vector.vector
+
+  val copy : {src : 'a region,
+              dst : 'a array,
+              dst_row : int,
+              dst_col : int} -> unit
+
+  val appi : traversal -> (int * int * 'a -> unit) -> 'a region -> unit
+  val app  : traversal -> ('a -> unit) -> 'a array -> unit
+  val foldi : traversal -> (int * int * 'a * 'b -> 'b) -> 'b -> 'a region -> 'b
+  val fold  : traversal -> ('a * 'b -> 'b) -> 'b -> 'a array -> 'b
+  val modifyi : traversal -> (int * int * 'a -> 'a) -> 'a region -> unit
+  val modify  : traversal -> ('a -> 'a) -> 'a array -> unit
 end
 
-(*
-Description
+(**
 
-type 'a region = {
-                   base : 'a array,
-                   row : int,
-                   col : int,
-                   nrows : int option,
-                   ncols : int option
-                 }
+[type 'a region] This type specifies a rectangular subregion of a
+2-dimensional array. If ncols equals SOME(w), with 0 <= w, the region
+includes only those elements in columns with indices in the range from
+col to col + (w - 1), inclusively. If ncols is NONE, the region
+includes only those elements lying on or to the right of column col. A
+similar interpretation holds for the row and nrows fields. Thus, the
+region corresponds to all those elements with position (i,j) such that
+i lies in the specified range of rows and j lies in the specified
+range of columns.
 
-    This type specifies a rectangular subregion of a 2-dimensional
-    array. If ncols equals SOME(w), with 0 <= w, the region includes
-    only those elements in columns with indices in the range from col
-    to col + (w - 1), inclusively. If ncols is NONE, the region
-    includes only those elements lying on or to the right of column
-    col. A similar interpretation holds for the row and nrows
-    fields. Thus, the region corresponds to all those elements with
-    position (i,j) such that i lies in the specified range of rows and
-    j lies in the specified range of columns.
+A region reg is said to be valid if it denotes a legal subarray of its
+base array. More specifically, reg is valid if
 
-    A region reg is said to be valid if it denotes a legal subarray of
-    its base array. More specifically, reg is valid if
+        0 <= #row reg <= nRows (#base reg)
 
-        0 <= #row reg <= nRows (#base reg) 
+when #nrows reg = NONE, or
 
-    when #nrows reg = NONE, or
+        0 <= #row reg <= (#row reg)+nr <= nRows (#base reg)
 
-        0 <= #row reg <= (#row reg)+nr <= nRows (#base reg) 
+when #nrows reg = SOME(nr), and the analogous conditions hold for
+columns.
 
-    when #nrows reg = SOME(nr), and the analogous conditions hold for
-    columns.
+[datatype traversal = RowMajor | ColMajor] This type specifies a way
+of traversing a region. Specifically, RowMajor indicates that, given a
+region, the rows are traversed from left to right (smallest column
+index to largest column index), starting with the first row in the
+region, then the second, and so on until the last row is
+traversed. ColMajor reverses the roles of row and column, traversing
+the columns from top down (smallest row index to largest row index),
+starting with the first column, then the second, and so on until the
+last column is traversed.
 
-datatype traversal = RowMajor | ColMajor
+[array (r, c, init)] creates a new array with r rows and c columns,
+with each element initialized to the value init. If r < 0, c < 0 or
+the resulting array would be too large, the Size exception is raised.
 
-    This type specifies a way of traversing a region. Specifically,
-    RowMajor indicates that, given a region, the rows are traversed
-    from left to right (smallest column index to largest column
-    index), starting with the first row in the region, then the
-    second, and so on until the last row is traversed. ColMajor
-    reverses the roles of row and column, traversing the columns from
-    top down (smallest row index to largest row index), starting with
-    the first column, then the second, and so on until the last column
-    is traversed.
+[fromList l] creates a new array from a list of a list of
+elements. The elements should be presented in row major form, i.e., hd
+l gives the first row, hd (tl l) gives the second row, etc. This
+raises the Size exception if the resulting array would be too large or
+if the lists in l do not all have the same length.
 
-array (r, c, init)
+[tabulate trv (r, c, f)] creates a new array with r rows and c
+columns, with the (i,j)(th) element initialized to f (i,j). The
+elements are initialized in the traversal order specified by trv. If r
+< 0, c < 0 or the resulting array would be too large, the Size
+exception is raised.
 
-    creates a new array with r rows and c columns, with each element
-    initialized to the value init. If r < 0, c < 0 or the resulting
-    array would be too large, the Size exception is raised.
+[sub (arr, i, j)] returns the (i,j)(th) element of the array arr. If i
+< 0, j < 0, nRows arr <= i, or nCols arr <= j, then the Subscript
+exception is raised.
 
-fromList l
+[update (arr, i, j, a)] sets the (i,j)(th) element of the array arr to
+a. If i < 0, j < 0, nRows arr <= i, or nCols arr <= j, then the
+Subscript exception is raised.
 
-    creates a new array from a list of a list of elements. The
-    elements should be presented in row major form, i.e., hd l gives
-    the first row, hd (tl l) gives the second row, etc. This raises
-    the Size exception if the resulting array would be too large or if
-    the lists in l do not all have the same length.
+[val dimensions : 'a array -> int * int]
+[val nCols : 'a array -> int]
+[val nRows : 'a array -> int]
 
-tabulate trv (r, c, f)
+These functions return size information concerning an array. nCols
+returns the number of columns, nRows returns the number of rows, and
+dimension returns a pair containing the number of rows and the number
+of columns of the array. The functions nRows and nCols are
+respectively equivalent to #1 o dimensions and #2 o dimensions
 
-    creates a new array with r rows and c columns, with the (i,j)(th)
-    element initialized to f (i,j). The elements are initialized in
-    the traversal order specified by trv. If r < 0, c < 0 or the
-    resulting array would be too large, the Size exception is raised.
+[row (arr, i)] returns row i of arr. If (nRows arr) <= i or i < 0,
+this raises Subscript.
 
-sub (arr, i, j)
+[column (arr, j)] returns column j of arr. This raises Subscript if j
+< 0 or nCols arr <= j.
 
-    returns the (i,j)(th) element of the array arr. If i < 0, j < 0,
-    nRows arr <= i, or nCols arr <= j, then the Subscript exception is
-    raised.
+[copy {src, dst, dst_row, dst_col}] copies the region src into the
+array dst, with the element at position (#row src, #col src) copied
+into the destination array at position (dst_row,dst_col). If the
+source region is not valid, then the Subscript exception is
+raised. Similarly, if the derived destination region (the source
+region src translated to (dst_row,dst_col)) is not valid in dst, then
+the Subscript exception is raised.
 
-update (arr, i, j, a)
-    sets the (i,j)(th) element of the array arr to a. If i < 0, j < 0, nRows arr <= i, or nCols arr <= j, then the Subscript exception is raised.
+Implementation note: The copy function must correctly handle the case
+in which the #base src and the dst arrays are equal, and the source
+and destination regions overlap.
 
-val dimensions : 'a array -> int * int
-val nCols : 'a array -> int
-val nRows : 'a array -> int
+[appi tr f reg]
+[app tr f arr]
+These functions apply the function f to the elements of an array in
+the order specified by tr. The more general appi function applies f to
+the elements of the region reg and supplies both the element and the
+element's coordinates in the base array to the function f. If reg is
+not valid, then the exception Subscript is raised.
 
-    These functions return size information concerning an array. nCols
-    returns the number of columns, nRows returns the number of rows,
-    and dimension returns a pair containing the number of rows and the
-    number of columns of the array. The functions nRows and nCols are
-    respectively equivalent to #1 o dimensions and #2 o dimensions
-
-row (arr, i)
-
-    returns row i of arr. If (nRows arr) <= i or i < 0, this raises
-    Subscript.
-
-column (arr, j)
-
-    returns column j of arr. This raises Subscript if j < 0 or nCols
-    arr <= j.
-
-copy {src, dst, dst_row, dst_col}
-
-    copies the region src into the array dst, with the element at
-    position (#row src, #col src) copied into the destination array at
-    position (dst_row,dst_col). If the source region is not valid,
-    then the Subscript exception is raised. Similarly, if the derived
-    destination region (the source region src translated to
-    (dst_row,dst_col)) is not valid in dst, then the Subscript
-    exception is raised.
-
-        Implementation note:
-
-        The copy function must correctly handle the case in which the
-        #base src and the dst arrays are equal, and the source and
-        destination regions overlap.
-
-appi tr f reg
-app tr f arr
-
-    These functions apply the function f to the elements of an array
-    in the order specified by tr. The more general appi function
-    applies f to the elements of the region reg and supplies both the
-    element and the element's coordinates in the base array to the
-    function f. If reg is not valid, then the exception Subscript is
-    raised.
-
-    The function app applies f to the whole array and does not supply
-    the element's coordinates to f. Thus, the expression app tr f arr
-    is equivalent to:
+The function app applies f to the whole array and does not supply the
+element's coordinates to f. Thus, the expression app tr f arr is
+equivalent to:
 
        let
 	 val range = {base=arr,row=0,col=0,nrows=NONE,ncols=NONE}
@@ -178,40 +154,38 @@ app tr f arr
 	 appi tr (f o #3) range
        end
 
-foldi tr f init reg
-fold tr f init arr
+[foldi tr f init reg]
+[fold tr f init arr]
+These functions fold the function f over the elements of an array arr,
+traversing the elements in tr order, and using the value init as the
+initial value. The more general foldi function applies f to the
+elements of the region reg and supplies both the element and the
+element's coordinates in the base array to the function f. If reg is
+not valid, then the exception Subscript is raised.
 
-    These functions fold the function f over the elements of an array
-    arr, traversing the elements in tr order, and using the value init
-    as the initial value. The more general foldi function applies f to
-    the elements of the region reg and supplies both the element and
-    the element's coordinates in the base array to the function f. If
-    reg is not valid, then the exception Subscript is raised.
+The function fold applies f to the whole array and does not supply the
+element's coordinates to f. Thus, the expression fold tr f init arr is
+equivalent to:
 
-    The function fold applies f to the whole array and does not supply
-    the element's coordinates to f. Thus, the expression fold tr f
-    init arr is equivalent to:
-
-       foldi tr (fn (_,_,a,b) => f (a,b)) init 
+       foldi tr (fn (_,_,a,b) => f (a,b)) init
 		  {base=arr, row=0, col=0, nrows=NONE, ncols=NONE}
 
-modifyi tr f reg
-modify tr f arr
+[modifyi tr f reg]
+[modify tr f arr]
+These functions apply the function f to the elements of an array in
+the order specified by tr, and replace each element with the result of
+f. The more general modifyi function applies f to the elements of the
+region reg and supplies both the element and the element's coordinates
+in the base array to the function f. If reg is not valid, then the
+exception Subscript is raised.
 
-    These functions apply the function f to the elements of an array
-    in the order specified by tr, and replace each element with the
-    result of f. The more general modifyi function applies f to the
-    elements of the region reg and supplies both the element and the
-    element's coordinates in the base array to the function f. If reg
-    is not valid, then the exception Subscript is raised.
-
-    The function modify applies f to the whole array and does not
-    supply the element's coordinates to f. Thus, the expression modify
-    tr f arr is equivalent to:
+The function modify applies f to the whole array and does not supply
+the element's coordinates to f. Thus, the expression modify tr f arr
+is equivalent to:
 
 	let
 	  val range = {base=arr,row=0,col=0,nrows=NONE,ncols=NONE}
 	in
-	  modifyi tr (f o #3) 
+	  modifyi tr (f o #3)
 	end
 *)

--- a/basis/Array2.sml
+++ b/basis/Array2.sml
@@ -27,11 +27,16 @@ fun sub2 (a : 'a array, cols:int, r:int, c:int) : 'a =
 fun update2 (a : 'a array, cols:int, r:int, c:int, v:'a) : unit =
     prim ("word_update0", (a, r*cols+c+2, v))
 
-(* word_table2d0 is in OptLambda compiled into calls to word_table0
-   and consecutive updates to store the sizes of each dimension in
-   slot 0 and 1. Similarly for word_table2d0_init, which is in
-   OptLambda compiled into calls to word_table_init and consecutive
-   updates to store the sizes of each dimension in slot 0 and 1.
+(* The primitive word_table2d0 is in OptLambda compiled into calls to
+   word_table0 and consecutive updates to store the sizes of each
+   dimension in slot 0 and 1. Similarly for word_table2d0_init, which
+   is in OptLambda compiled into calls to word_table_init and
+   consecutive updates to store the sizes of each dimension in slot 0
+   and 1.
+
+   It is safe (also when gc is enabled) to store integers in the first
+   slots of arrays allocated with word_table0 as the integers are
+   tagged when gc is enabled.
 *)
 
 fun table2d0 (n:int,r:int,c:int) : 'a array = prim ("word_table2d0", (n,r,c))

--- a/basis/wordtables.sml
+++ b/basis/wordtables.sml
@@ -31,23 +31,23 @@ struct
 
   fun length_vector (t : 'a vector) : int = prim ("table_size", t)
 
-  fun array0 (n : int, x:'a) : 'a array = prim ("word_table_init", (n, x))    
+  fun array0 (n : int, x:'a) : 'a array = prim ("word_table_init", (n, x))
 
   (* 26 bits are reserved for the length in the tag field; maxLen = 2^26 *)
   val maxLen = 123456789 (* arbitrary chosen. *)
 
-  fun check_index (n, i) = 
-    if 0 <= i andalso i < n then () 
+  fun check_index (n, i) =
+    if 0 <= i andalso i < n then ()
     else raise Subscript
 
-  fun check_size n = 
-    if 0 <= n andalso n <= maxLen then () 
+  fun check_size n =
+    if 0 <= n andalso n <= maxLen then ()
     else raise Size
 
-  fun sub (t : 'a table, i:int) : 'a = 
+  fun sub (t : 'a table, i:int) : 'a =
     (check_index(length t, i); sub0(t,i))
 
-  fun update (t, i, x) = 
+  fun update (t, i, x) =
     (check_index(length t, i); update0(t,i,x))
 
   (* table n returns an uninitialised table with n elements.
@@ -61,110 +61,112 @@ struct
   (* array n gives an initialised array with n elements. *)
   (* Raise Size if n > maxLen.                           *)
   fun array (n, x) = (check_size n; array0 (n, x))
-    
+
   (* fromList creates a table from a list of elements *)
   fun fromList (xs : 'a list) =
-    let 
+    let
       fun init (t, [], i) = t
 	| init (t, x::xs, i) = (update0 (t, i, x); init (t, xs, i+1))
       val n = List.length xs
-    in 
+    in
       init (table n, xs, 0)
     end
 
   (* tabulate creates a table of n elements *)
   fun tabulate (n, f : int -> 'a) =
-    let fun init (t, f, i) = if i >= n then t
-			     else (update0 (t, i, f i); init (t, f, i+1))
-    in init (table n, f, 0) 
-    end
+      let fun init f (t, i) = if i >= n then ()
+			      else (update0 (t, i, f i); init f (t, i+1))
+          val t = table n
+      in init f (t, 0)
+       ; t
+      end
 
   fun tabulatev (n, f : int -> 'a) =
     let fun init (t, f, i) = if i >= n then t
 			     else (update_vector0 (t, i, f i); init (t, f, i+1))
-    in init (vector0 n, f, 0) 
+    in init (vector0 n, f, 0)
     end
 
   fun vector a = tabulatev (length a, fn i => sub0(a,i))
 
   fun updatev (t, i, x) =
-      (check_index(length t, i); 
+      (check_index(length t, i);
        tabulate (length t,fn j => if i=j then x else sub0(t,j)))
 
   fun copy {src=a1: 'a table, dst=a2: 'a table, di=i2} =
     let val n = length a1
     in
-	if i2<0 orelse i2+n > length a2 then 
+	if i2<0 orelse i2+n > length a2 then
 	    raise Subscript
 	else		(* copy from high to low *)
-	    let fun hi2lo j = 
+	    let fun hi2lo j =
 		    if j >= 0 then
 			(update0(a2, i2+j,sub0(a1,j)); hi2lo (j-1))
 		    else ()
-	    in hi2lo (n-1) 
+	    in hi2lo (n-1)
 	    end
     end
 
   fun copyVec {src=v: 'a vector, dst=a: 'a table, di=i2} =
     let val n = length_vector v
     in
-	if i2<0 orelse i2+n > length a then 
+	if i2<0 orelse i2+n > length a then
 	    raise Subscript
-	else 
-	    let fun lo2hi j = 
+	else
+	    let fun lo2hi j =
 		    if j < n then
 			(update0(a,i2+j,sub_vector0(v,j)); lo2hi (j+1))
 		    else ()
-	    in lo2hi 0 
+	    in lo2hi 0
 	    end
     end
 
   (* apply f on the elements from left to right. *)
   fun app f a =
     let val n = length a
-        fun lr j = 
-	  if j < n then (f (sub0 (a, j)); lr (j+1)) 
+        fun lr j =
+	  if j < n then (f (sub0 (a, j)); lr (j+1))
 	  else ()
     in lr 0
     end
 
-  fun foldli f e a = 
+  fun foldli f e a =
     let val stop = length a
-	fun lr j res = 
+	fun lr j res =
 	    if j < stop then lr (j+1) (f(j, sub0(a,j), res))
 	    else res
-    in lr 0 e 
+    in lr 0 e
     end
 
-  fun foldri f e a = 
-    let fun rl j res = 
+  fun foldri f e a =
+    let fun rl j res =
 	    if j >= 0 then rl (j-1) (f(j, sub0(a,j), res))
 	    else res
-    in rl (length a - 1) e 
+    in rl (length a - 1) e
     end
 
-  fun appi f a = 
+  fun appi f a =
     let val stop = length a
-	fun lr j = 
-	    if j < stop then (f(j, sub0(a,j)); lr (j+1)) 
+	fun lr j =
+	    if j < stop then (f(j, sub0(a,j)); lr (j+1))
 	    else ()
-    in lr 0 
+    in lr 0
     end
 
-  fun mapi (f : int * 'a -> 'b) (a : 'a table) : 'b table = 
+  fun mapi (f : int * 'a -> 'b) (a : 'a table) : 'b table =
     let val stop = length a
-	val newvec = table0 stop 
-	fun lr j = 
-	    if j < stop then 
+	val newvec = table0 stop
+	fun lr j =
+	    if j < stop then
 		(update0(newvec, j, f(j, sub0(a,j)));
-		 lr (j+1)) 
+		 lr (j+1))
 	    else ()
-    in lr 0; newvec 
+    in lr 0; newvec
     end
 
   fun foldl f e a =
     let val n = length a
-	fun lr (j, res) = 
+	fun lr (j, res) =
 	  if j < n then lr (j+1, f (sub0 (a, j), res))
 	  else res
     in lr (0, e)
@@ -172,23 +174,23 @@ struct
 
   fun foldr f e a =
     let val n = length a
-        fun rl (j, res) = 
+        fun rl (j, res) =
 	  if j >= 0 then rl (j-1, f (sub0 (a, j), res))
 	  else res
     in rl (n-1, e)
     end
 
-  fun modifyi f a = 
+  fun modifyi f a =
     let val stop = length a
-	fun lr j = 
+	fun lr j =
 	    if j < stop then (update0(a,j,f(j, sub0(a,j))); lr (j+1))
 	    else ()
-    in lr 0 
+    in lr 0
     end
 
   fun modify f a =
-    let val n = length a 
-        fun lr j = 
+    let val n = length a
+        fun lr j =
 	  if j < n then (update0 (a, j, f (sub0 (a, j))); lr (j+1))
 	  else ()
     in lr 0
@@ -198,25 +200,25 @@ struct
   fun map (f : 'a -> 'b) (a : 'a table) : 'b table =
     let val n = length a
         val b : 'b table = table n
-	fun lr j = 
+	fun lr j =
 	  if j < n then (update0 (b, j, f (sub0 (a, j))); lr (j+1))
 	  else b
-    in lr 0 
+    in lr 0
     end
 
-  fun mapi (f : int * 'a -> 'b) (a : 'a table) : 'b table = 
+  fun mapi (f : int * 'a -> 'b) (a : 'a table) : 'b table =
     let val stop = length a
-	val newvec = table0 stop 
-	fun lr j = 
-	    if j < stop then 
-		(update0(newvec, j, f(j, sub0(a,j))); 
+	val newvec = table0 stop
+	fun lr j =
+	    if j < stop then
+		(update0(newvec, j, f(j, sub0(a,j)));
 		 lr (j+1))
 	    else ()
-    in lr 0; newvec 
+    in lr 0; newvec
     end
 
   fun concat (vecs : 'a table list) =
-    let 
+    let
       fun total_length ([], n) = n
 	| total_length (v::vs, n) = total_length (vs, length v + n);
       val n = total_length (vecs, 0)
@@ -232,39 +234,39 @@ struct
     in copyall (0, vecs)
     end
 
-  fun findi (p : int * 'a -> bool) (a : 'a table) : (int * 'a) option = 
+  fun findi (p : int * 'a -> bool) (a : 'a table) : (int * 'a) option =
     let val stop = length a
-	fun lr j = 
-	    if j < stop then 
+	fun lr j =
+	    if j < stop then
 		if p (j, sub0(a,j)) then SOME (j, sub0(a,j)) else lr (j+1)
 	    else NONE
-    in lr 0 
+    in lr 0
     end
 
-  fun find (p : 'a -> bool) (a : 'a table) : 'a option = 
+  fun find (p : 'a -> bool) (a : 'a table) : 'a option =
     let val stop = length a
-	fun lr j = 
-	    if j < stop then 
-		if p (sub0(a,j)) then SOME (sub0 (a,j)) 
+	fun lr j =
+	    if j < stop then
+		if p (sub0(a,j)) then SOME (sub0 (a,j))
 		else lr (j+1)
 	    else NONE
-    in lr 0 
+    in lr 0
     end
 
-  fun exists (p : 'a -> bool) (a : 'a table) : bool = 
+  fun exists (p : 'a -> bool) (a : 'a table) : bool =
     let val stop = length a
 	fun lr j = j < stop andalso (p (sub0(a,j)) orelse lr (j+1))
-    in lr 0 
+    in lr 0
     end
 
-  fun all (p : 'a -> bool) (a : 'a table) : bool = 
+  fun all (p : 'a -> bool) (a : 'a table) : bool =
     let val stop = length a
 	fun lr j = j >= stop orelse (p (sub0(a,j)) andalso lr (j+1))
-    in lr 0 
+    in lr 0
     end
 
   fun collate cmp (v1, v2) =
-    let val n1 = length v1 
+    let val n1 = length v1
 	and n2 = length v2
 	val stop = if n1 < n2 then n1 else n2
 	fun h j = (* At this point v1[0..j-1] = v2[0..j-1] *)
@@ -275,6 +277,6 @@ struct
 		case cmp(sub0(v1,j), sub0(v2,j)) of
 		    EQUAL => h (j+1)
 		  | res   => res
-    in h 0 
+    in h 0
     end
 end; (*functor table*)

--- a/js/basis/wordtables.sml
+++ b/js/basis/wordtables.sml
@@ -31,23 +31,23 @@ struct
 
   fun length_vector (t : 'a vector) : int = prim ("table_size", t)
 
-  fun array0 (n : int, x:'a) : 'a array = prim ("word_table_init", (n, x))    
+  fun array0 (n : int, x:'a) : 'a array = prim ("word_table_init", (n, x))
 
   (* 26 bits are reserved for the length in the tag field; maxLen = 2^26 *)
   val maxLen = 123456789 (* arbitrary chosen. *)
 
-  fun check_index (n, i) = 
-    if 0 <= i andalso i < n then () 
+  fun check_index (n, i) =
+    if 0 <= i andalso i < n then ()
     else raise Subscript
 
-  fun check_size n = 
-    if 0 <= n andalso n <= maxLen then () 
+  fun check_size n =
+    if 0 <= n andalso n <= maxLen then ()
     else raise Size
 
-  fun sub (t : 'a table, i:int) : 'a = 
+  fun sub (t : 'a table, i:int) : 'a =
     (check_index(length t, i); sub0(t,i))
 
-  fun update (t, i, x) = 
+  fun update (t, i, x) =
     (check_index(length t, i); update0(t,i,x))
 
   (* table n returns an uninitialised table with n elements.
@@ -61,110 +61,112 @@ struct
   (* array n gives an initialised array with n elements. *)
   (* Raise Size if n > maxLen.                           *)
   fun array (n, x) = (check_size n; array0 (n, x))
-    
+
   (* fromList creates a table from a list of elements *)
   fun fromList (xs : 'a list) =
-    let 
+    let
       fun init (t, [], i) = t
 	| init (t, x::xs, i) = (update0 (t, i, x); init (t, xs, i+1))
       val n = List.length xs
-    in 
+    in
       init (table n, xs, 0)
     end
 
   (* tabulate creates a table of n elements *)
   fun tabulate (n, f : int -> 'a) =
-    let fun init (t, f, i) = if i >= n then t
-			     else (update0 (t, i, f i); init (t, f, i+1))
-    in init (table n, f, 0) 
-    end
+      let fun init f (t, i) = if i >= n then ()
+			      else (update0 (t, i, f i); init f (t, i+1))
+          val t = table n
+      in init f (t, 0)
+       ; t
+      end
 
   fun tabulatev (n, f : int -> 'a) =
     let fun init (t, f, i) = if i >= n then t
 			     else (update_vector0 (t, i, f i); init (t, f, i+1))
-    in init (vector0 n, f, 0) 
+    in init (vector0 n, f, 0)
     end
 
   fun vector a = tabulatev (length a, fn i => sub0(a,i))
 
   fun updatev (t, i, x) =
-      (check_index(length t, i); 
+      (check_index(length t, i);
        tabulate (length t,fn j => if i=j then x else sub0(t,j)))
 
   fun copy {src=a1: 'a table, dst=a2: 'a table, di=i2} =
     let val n = length a1
     in
-	if i2<0 orelse i2+n > length a2 then 
+	if i2<0 orelse i2+n > length a2 then
 	    raise Subscript
 	else		(* copy from high to low *)
-	    let fun hi2lo j = 
+	    let fun hi2lo j =
 		    if j >= 0 then
 			(update0(a2, i2+j,sub0(a1,j)); hi2lo (j-1))
 		    else ()
-	    in hi2lo (n-1) 
+	    in hi2lo (n-1)
 	    end
     end
 
   fun copyVec {src=v: 'a vector, dst=a: 'a table, di=i2} =
     let val n = length_vector v
     in
-	if i2<0 orelse i2+n > length a then 
+	if i2<0 orelse i2+n > length a then
 	    raise Subscript
-	else 
-	    let fun lo2hi j = 
+	else
+	    let fun lo2hi j =
 		    if j < n then
 			(update0(a,i2+j,sub_vector0(v,j)); lo2hi (j+1))
 		    else ()
-	    in lo2hi 0 
+	    in lo2hi 0
 	    end
     end
 
   (* apply f on the elements from left to right. *)
   fun app f a =
     let val n = length a
-        fun lr j = 
-	  if j < n then (f (sub0 (a, j)); lr (j+1)) 
+        fun lr j =
+	  if j < n then (f (sub0 (a, j)); lr (j+1))
 	  else ()
     in lr 0
     end
 
-  fun foldli f e a = 
+  fun foldli f e a =
     let val stop = length a
-	fun lr j res = 
+	fun lr j res =
 	    if j < stop then lr (j+1) (f(j, sub0(a,j), res))
 	    else res
-    in lr 0 e 
+    in lr 0 e
     end
 
-  fun foldri f e a = 
-    let fun rl j res = 
+  fun foldri f e a =
+    let fun rl j res =
 	    if j >= 0 then rl (j-1) (f(j, sub0(a,j), res))
 	    else res
-    in rl (length a - 1) e 
+    in rl (length a - 1) e
     end
 
-  fun appi f a = 
+  fun appi f a =
     let val stop = length a
-	fun lr j = 
-	    if j < stop then (f(j, sub0(a,j)); lr (j+1)) 
+	fun lr j =
+	    if j < stop then (f(j, sub0(a,j)); lr (j+1))
 	    else ()
-    in lr 0 
+    in lr 0
     end
 
-  fun mapi (f : int * 'a -> 'b) (a : 'a table) : 'b table = 
+  fun mapi (f : int * 'a -> 'b) (a : 'a table) : 'b table =
     let val stop = length a
-	val newvec = table0 stop 
-	fun lr j = 
-	    if j < stop then 
+	val newvec = table0 stop
+	fun lr j =
+	    if j < stop then
 		(update0(newvec, j, f(j, sub0(a,j)));
-		 lr (j+1)) 
+		 lr (j+1))
 	    else ()
-    in lr 0; newvec 
+    in lr 0; newvec
     end
 
   fun foldl f e a =
     let val n = length a
-	fun lr (j, res) = 
+	fun lr (j, res) =
 	  if j < n then lr (j+1, f (sub0 (a, j), res))
 	  else res
     in lr (0, e)
@@ -172,23 +174,23 @@ struct
 
   fun foldr f e a =
     let val n = length a
-        fun rl (j, res) = 
+        fun rl (j, res) =
 	  if j >= 0 then rl (j-1, f (sub0 (a, j), res))
 	  else res
     in rl (n-1, e)
     end
 
-  fun modifyi f a = 
+  fun modifyi f a =
     let val stop = length a
-	fun lr j = 
+	fun lr j =
 	    if j < stop then (update0(a,j,f(j, sub0(a,j))); lr (j+1))
 	    else ()
-    in lr 0 
+    in lr 0
     end
 
   fun modify f a =
-    let val n = length a 
-        fun lr j = 
+    let val n = length a
+        fun lr j =
 	  if j < n then (update0 (a, j, f (sub0 (a, j))); lr (j+1))
 	  else ()
     in lr 0
@@ -198,25 +200,25 @@ struct
   fun map (f : 'a -> 'b) (a : 'a table) : 'b table =
     let val n = length a
         val b : 'b table = table n
-	fun lr j = 
+	fun lr j =
 	  if j < n then (update0 (b, j, f (sub0 (a, j))); lr (j+1))
 	  else b
-    in lr 0 
+    in lr 0
     end
 
-  fun mapi (f : int * 'a -> 'b) (a : 'a table) : 'b table = 
+  fun mapi (f : int * 'a -> 'b) (a : 'a table) : 'b table =
     let val stop = length a
-	val newvec = table0 stop 
-	fun lr j = 
-	    if j < stop then 
-		(update0(newvec, j, f(j, sub0(a,j))); 
+	val newvec = table0 stop
+	fun lr j =
+	    if j < stop then
+		(update0(newvec, j, f(j, sub0(a,j)));
 		 lr (j+1))
 	    else ()
-    in lr 0; newvec 
+    in lr 0; newvec
     end
 
   fun concat (vecs : 'a table list) =
-    let 
+    let
       fun total_length ([], n) = n
 	| total_length (v::vs, n) = total_length (vs, length v + n);
       val n = total_length (vecs, 0)
@@ -232,39 +234,39 @@ struct
     in copyall (0, vecs)
     end
 
-  fun findi (p : int * 'a -> bool) (a : 'a table) : (int * 'a) option = 
+  fun findi (p : int * 'a -> bool) (a : 'a table) : (int * 'a) option =
     let val stop = length a
-	fun lr j = 
-	    if j < stop then 
+	fun lr j =
+	    if j < stop then
 		if p (j, sub0(a,j)) then SOME (j, sub0(a,j)) else lr (j+1)
 	    else NONE
-    in lr 0 
+    in lr 0
     end
 
-  fun find (p : 'a -> bool) (a : 'a table) : 'a option = 
+  fun find (p : 'a -> bool) (a : 'a table) : 'a option =
     let val stop = length a
-	fun lr j = 
-	    if j < stop then 
-		if p (sub0(a,j)) then SOME (sub0 (a,j)) 
+	fun lr j =
+	    if j < stop then
+		if p (sub0(a,j)) then SOME (sub0 (a,j))
 		else lr (j+1)
 	    else NONE
-    in lr 0 
+    in lr 0
     end
 
-  fun exists (p : 'a -> bool) (a : 'a table) : bool = 
+  fun exists (p : 'a -> bool) (a : 'a table) : bool =
     let val stop = length a
 	fun lr j = j < stop andalso (p (sub0(a,j)) orelse lr (j+1))
-    in lr 0 
+    in lr 0
     end
 
-  fun all (p : 'a -> bool) (a : 'a table) : bool = 
+  fun all (p : 'a -> bool) (a : 'a table) : bool =
     let val stop = length a
 	fun lr j = j >= stop orelse (p (sub0(a,j)) andalso lr (j+1))
-    in lr 0 
+    in lr 0
     end
 
   fun collate cmp (v1, v2) =
-    let val n1 = length v1 
+    let val n1 = length v1
 	and n2 = length v2
 	val stop = if n1 < n2 then n1 else n2
 	fun h j = (* At this point v1[0..j-1] = v2[0..j-1] *)
@@ -275,6 +277,6 @@ struct
 		case cmp(sub0(v1,j), sub0(v2,j)) of
 		    EQUAL => h (j+1)
 		  | res   => res
-    in h 0 
+    in h 0
     end
 end; (*functor table*)

--- a/src/Compiler/Backend/X64/CodeGenUtilX64.sml
+++ b/src/Compiler/Backend/X64/CodeGenUtilX64.sml
@@ -2640,7 +2640,7 @@ struct
                | NONE =>
                 (move_aty_into_reg(i,tmp_reg1,size_ff,            (* tmp_reg1 = i *)
                  I.sarq(I "1", R tmp_reg1) ::                     (* untag i: tmp_reg1 >> 1 *)
-                 I.salq(I "2", R tmp_reg1) ::                     (* i << 2 *)
+                 I.salq(I "3", R tmp_reg1) ::                     (* i << 3 *)
                  move_aty_into_reg(t,tmp_reg0,size_ff,            (* tmp_reg0 = t *)
                  I.addq(R tmp_reg0, R tmp_reg1) ::                (* tmp_reg1 += tmp_reg0 *)
                  move_aty_into_reg(x,tmp_reg0,size_ff,            (* tmp_reg0 = x *)
@@ -2655,7 +2655,7 @@ struct
              | SOME _ => die "word_update0_2"
              | NONE =>
               move_aty_into_reg(i,tmp_reg1,size_ff,            (* tmp_reg1 = i *)
-              I.imulq(I "4", R tmp_reg1) ::                    (* i << 2 *)
+              I.salq(I "3", R tmp_reg1) ::                     (* i << 3 *)
               move_aty_into_reg(t,tmp_reg0,size_ff,            (* tmp_reg0 = t *)
               I.addq(R tmp_reg0, R tmp_reg1) ::                (* tmp_reg1 += tmp_reg0 *)
               move_aty_into_reg(x,tmp_reg0,size_ff,            (* tmp_reg0 = x *)
@@ -2701,7 +2701,7 @@ struct
                | NONE =>
                 (move_aty_into_reg(i,tmp_reg1,size_ff,            (* tmp_reg1 = i *)
                  I.sarq(I "1", R tmp_reg1) ::                     (* untag i: tmp_reg1 >> 1 *)
-                 I.salq(I "2", R tmp_reg1) ::                     (* i << 2 *)
+                 I.salq(I "3", R tmp_reg1) ::                     (* i << 3 *)
                  move_aty_into_reg(t,tmp_reg0,size_ff,            (* tmp_reg0 = t *)
                  I.addq(R tmp_reg0, R tmp_reg1) ::                (* tmp_reg1 += tmp_reg0 *)
                  load_real(x,tmp_reg0,size_ff,tmp_freg0)          (* tmp_freg0 = !x *)
@@ -2717,7 +2717,7 @@ struct
              | SOME _ => die "blockf64_update_real_2"
              | NONE =>
               move_aty_into_reg(i,tmp_reg1,size_ff,            (* tmp_reg1 = i *)
-              I.imulq(I "4", R tmp_reg1) ::                    (* i << 2 *)
+              I.salq(I "3", R tmp_reg1) ::                     (* i << 3 *)
               move_aty_into_reg(t,tmp_reg0,size_ff,            (* tmp_reg0 = t *)
               I.addq(R tmp_reg0, R tmp_reg1) ::                (* tmp_reg1 += tmp_reg0 *)
               load_real(x,tmp_reg0,size_ff,tmp_freg0)          (* tmp_freg0 = !x *)

--- a/src/Compiler/Lambda/OptLambda.sml
+++ b/src/Compiler/Lambda/OptLambda.sml
@@ -122,7 +122,7 @@ structure OptLambda: OPT_LAMBDA =
     val max_inline_size = Flags.add_int_entry
 	{long="maximum_inline_size", short=NONE,
 	 menu=["Control", "Optimiser", "maximum inline size"],
-	 item=ref 50, desc=
+	 item=ref 70, desc=
 	 "Functions smaller than this size (counted in abstract\n\
 	  \syntax tree nodes) are inlined, even if they are used\n\
 	  \more than once. Functions that are used only once are\n\
@@ -1664,6 +1664,12 @@ structure OptLambda: OPT_LAMBDA =
                 let val lambs' = map (fst o (fn e => contr (env, e))) lambs
                 in case lambs' of
                        [INTEGER(v,_),e] => (PRIM(p,lambs'),CBLKSZ v)
+                     | _ => (PRIM(p,lambs'),CUNKNOWN)
+                end
+              | PRIM(p as CCALLprim{name="word_table0",...},lambs) =>
+                let val lambs' = map (fst o (fn e => contr (env, e))) lambs
+                in case lambs' of
+                       [INTEGER(v,_)] => (PRIM(p,lambs'),CBLKSZ v)
                      | _ => (PRIM(p,lambs'),CUNKNOWN)
                 end
               | PRIM(p as CCALLprim{name="ord",...},[e]) =>

--- a/test/arr2a.sml
+++ b/test/arr2a.sml
@@ -1,0 +1,10 @@
+
+local
+  val a = Array2.array (100,10,23)
+  fun set(r,c,v) = Array2.update(a,r,c,v)
+  fun get(r,c) = Array2.sub(a,r,c)
+  val () = set(5,8,24)
+  val () = print (Int.toString (get (50,7)) ^ "\n")
+  val () = print (Int.toString (get (5,8)) ^ "\n")
+in
+end


### PR DESCRIPTION
- [X] Avoid using an additional indirection for Array2.array values. Instead, use a representation of `'a array = 'a Array.array`, where the first and second elements hold size information for the first and second dimension, respectively.

- [x] Open up for the possibility of removing array bounds checking when possible also in cases where 2d-array subscriptions and updates are applied directly in user code.

To avoid array bounds checks, we introduce the following primitives:

```
val word_table2d0 : int * int * int -> 'a array
val word_table2d0_init : int * 'a * int * int -> 'a array
```

These operations are eliminated (compiled away) as the last step in `OptLambda.sml`. The optimiser will propagate static information about the size of arrays created with `word_table2d0` and `word_table_2d_init`. Calls to `nRows` (`word_sub0(a,0)`) and `nCols` (`word_sub0(a,1)`) will be replaced with the statically known sizes, which may open up for certain checks to be resolved statically...

We could perhaps improve the static analysis techniques used to cover more cases. Currently, we can at least deal with immediate indexes into statically sized arrays; see e.g. `test/arr2a.sml`.