### PR TITLE
Add 'Float.rem'.

### DIFF
--- a/basis/REAL.sig
+++ b/basis/REAL.sig
@@ -10,6 +10,7 @@ signature REAL = sig
   val -    : real * real -> real
   val *    : real * real -> real
   val /    : real * real -> real
+  val rem  : real * real -> real
   val abs  : real -> real
   val min  : real * real -> real
   val max  : real * real -> real

--- a/basis/Real.sml
+++ b/basis/Real.sml
@@ -10,6 +10,7 @@ structure Real : REAL =
     fun trunc (x : real) : int = prim ("truncFloat", x)    (* may raise Overflow *)
 
     fun (x: real) / (y: real): real = prim ("divFloat", (x, y))
+    fun rem (x: real, y: real): real = prim ("remFloat", (x, y))
     fun to_string_gen (s : string) (x : real) : string =
       prim ("generalStringOfFloat", (s,x))
     fun toString (x : real) : string = prim ("stringOfFloat", x)

--- a/js/basis/REAL.sig
+++ b/js/basis/REAL.sig
@@ -25,6 +25,7 @@ signature REAL = sig
   val -    : real * real -> real
   val *    : real * real -> real
   val /    : real * real -> real
+  val rem  : real * real -> real
   val abs  : real -> real
   val min  : real * real -> real
   val max  : real * real -> real

--- a/js/basis/Real.sml
+++ b/js/basis/Real.sml
@@ -10,6 +10,7 @@ structure Real : REAL =
     fun trunc (x : real) : int = prim ("truncFloat", x)    (* may raise Overflow *)
 
     fun (x: real) / (y: real): real = prim ("divFloat", (x, y))
+    fun rem (x: real, y: real): real = prim ("remFloat", (x, y))
 
     fun sub_unsafe (s:string,i:int) : char = prim ("__bytetable_sub", (s,i))
 

--- a/src/Compiler/Backend/JS/ExpToJs.sml
+++ b/src/Compiler/Backend/JS/ExpToJs.sml
@@ -455,6 +455,7 @@ fun pToJs2 name e1 e2 =
     | "__rem_int32ub" => parJs(e1 & $"%" & e2)
 
     | "divFloat" => parJs(e1 & $"/" & e2)
+    | "remFloat" => parJs(e1 & $"%" & e2)
     | "atan2Float" => $"Math.atan2" & seq[e1,e2]
 
     | "powFloat" => $"Math.pow" & seq[e1,e2]

--- a/src/Compiler/Backend/JS/ExpToJs2.sml
+++ b/src/Compiler/Backend/JS/ExpToJs2.sml
@@ -439,6 +439,7 @@ fun pToJs2 name e1 e2 : J.exp =
     | "__rem_int32ub" => J.Prim("%",[e1,e2])
 
     | "divFloat" => J.Prim("/",[e1,e2])
+    | "remFloat" => J.Prim("%",[e1,e2])
     | "__div_f64" => J.Prim("/",[e1,e2])
     | "atan2Float" => callPrim2 "Math.atan2" e1 e2
 

--- a/src/Compiler/Backend/KAM/BuiltInCFunctions.spec
+++ b/src/Compiler/Backend/KAM/BuiltInCFunctions.spec
@@ -38,6 +38,7 @@ __quot_int31
 __rem_int32ub
 __rem_int31
 divFloat
+remFloat
 sinFloat
 cosFloat
 atanFloat

--- a/src/Runtime/Math.c
+++ b/src/Runtime/Math.c
@@ -489,6 +489,14 @@ divFloat(ssize_t d, ssize_t x, ssize_t y)
   return d;
 }
 
+ssize_t
+remFloat(ssize_t d, ssize_t x, ssize_t y)
+{
+  get_d(d) = fmod(get_d(x), get_d(y));
+  set_dtag(d);
+  return d;
+}
+
 long int
 floorFloat(ssize_t f)
 {

--- a/src/Runtime/Math.h
+++ b/src/Runtime/Math.h
@@ -81,6 +81,7 @@ ssize_t ceilFloat(ssize_t f);
 ssize_t roundFloat(ssize_t f);
 ssize_t truncFloat(ssize_t f);
 ssize_t divFloat(ssize_t d, ssize_t x, ssize_t y);
+ssize_t remFloat(ssize_t d, ssize_t x, ssize_t y);
 
 ssize_t sqrtFloat(ssize_t d, ssize_t s);
 ssize_t sinFloat(ssize_t d, ssize_t s);


### PR DESCRIPTION
This is required by the ML Basis library.

Tested with the x86 backend, but not with the Javascript backend.