### PR TITLE
Add Real.{realFloor|realCeil|realTrunc|realRound} functions.

### DIFF
--- a/basis/REAL.sig
+++ b/basis/REAL.sig
@@ -22,6 +22,11 @@ signature REAL = sig
   val fromDefault : real -> real
   val fromInt     : int -> real
 
+  val realFloor : real -> real
+  val realCeil  : real -> real
+  val realTrunc : real -> real
+  val realRound : real -> real
+
   val floor : real -> int
   val ceil  : real -> int
   val trunc : real -> int

--- a/basis/Real.sml
+++ b/basis/Real.sml
@@ -9,6 +9,11 @@ structure Real : REAL =
     fun ceil (x : real) : int = prim ("ceilFloat", x)      (* may raise Overflow *)
     fun trunc (x : real) : int = prim ("truncFloat", x)    (* may raise Overflow *)
 
+    fun realFloor (x: real) : real = prim ("realFloor", x)
+    fun realCeil (x: real) : real = prim ("realCeil", x)
+    fun realTrunc (x: real) : real = prim ("realTrunc", x)
+    fun realRound (x: real) : real = prim ("realRound", x)
+
     fun (x: real) / (y: real): real = prim ("divFloat", (x, y))
     fun rem (x: real, y: real): real = prim ("remFloat", (x, y))
     fun to_string_gen (s : string) (x : real) : string =

--- a/src/Compiler/Backend/KAM/BuiltInCFunctions.spec
+++ b/src/Compiler/Backend/KAM/BuiltInCFunctions.spec
@@ -39,6 +39,10 @@ __rem_int32ub
 __rem_int31
 divFloat
 remFloat
+realFloor
+realCeil
+realTrunc
+realRound
 sinFloat
 cosFloat
 atanFloat

--- a/src/Runtime/Math.c
+++ b/src/Runtime/Math.c
@@ -497,6 +497,38 @@ remFloat(ssize_t d, ssize_t x, ssize_t y)
   return d;
 }
 
+ssize_t
+realFloor(ssize_t d, ssize_t x)
+{
+  get_d(d) = floor(get_d(x));
+  set_dtag(d);
+  return d;
+}
+
+ssize_t
+realCeil(ssize_t d, ssize_t x)
+{
+  get_d(d) = ceil(get_d(x));
+  set_dtag(d);
+  return d;
+}
+
+ssize_t
+realTrunc(ssize_t d, ssize_t x)
+{
+  get_d(d) = trunc(get_d(x));
+  set_dtag(d);
+  return d;
+}
+
+ssize_t
+realRound(ssize_t d, ssize_t x)
+{
+  get_d(d) = round(get_d(x));
+  set_dtag(d);
+  return d;
+}
+
 long int
 floorFloat(ssize_t f)
 {

--- a/src/Runtime/Math.h
+++ b/src/Runtime/Math.h
@@ -80,6 +80,10 @@ ssize_t floorFloat(ssize_t f);
 ssize_t ceilFloat(ssize_t f);
 ssize_t roundFloat(ssize_t f);
 ssize_t truncFloat(ssize_t f);
+ssize_t realFloor(ssize_t d, ssize_t x);
+ssize_t realCeil(ssize_t d, ssize_t x);
+ssize_t realTrunc(ssize_t d, ssize_t x);
+ssize_t realRound(ssize_t d, ssize_t x);
 ssize_t divFloat(ssize_t d, ssize_t x, ssize_t y);
 ssize_t remFloat(ssize_t d, ssize_t x, ssize_t y);
 


### PR DESCRIPTION
These are part of the basis library definition, but missing until now.

Only defined for the native backend, not the JS backend.