### PR TITLE
Non-atomic allocation 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,15 @@
 ## MLKit NEWS
 
+* mael 2021-02-17: Preliminary support for fork-join based
+  task-parallelism. See the `par-benchmarks` folder in the
+  [mlkit-bench](http://github.com/melsman/mlkit-bench) github
+  repository for examples.
+
+* mael 2021-02-17: Prettier priniting of multiplicity terms (e.g.,
+  -Pcee).
+
+### MLKit version 4.5.7 is released
+
 * mael 2020-11-09: Fixed error with respect to `-report_gc` and
   `-verbose_gc` (issue #50).
 

--- a/src/Runtime/Region.h
+++ b/src/Runtime/Region.h
@@ -408,9 +408,15 @@ void deallocateRegionsUntil_X64(Region rAddr);
 #endif
 
 uintptr_t *alloc (Region r, size_t n);
-uintptr_t *allocGen (Gen *gen, size_t n);
 uintptr_t *alloc_new_block(Gen *gen);
 void callSbrk();
+
+#ifdef PARALLEL_GLOBAL_ALLOC_LOCK
+uintptr_t *alloc_unprotected (Region r, size_t n);
+uintptr_t *allocGen (Gen *gen, size_t n, int protect_p);
+#else
+uintptr_t *allocGen (Gen *gen, size_t n);
+#endif
 
 #ifdef ENABLE_GC_OLD
 void callSbrkArg(size_t no_of_region_pages);


### PR DESCRIPTION
Support non-atomic allocation for programs where one can statically guarantee that different threads do not allocate into the same region. Use the option `-par0` together with `-par`. A good examples that benefits from this feature is [parallel merge sort](https://github.com/melsman/mlkit-bench/blob/master/par-benchmarks/pmsort/pmsort.sml), which utilises region polymorphism to ensure that local parallel sorts are performed in private regions. 
 
We will expand on this feature later to allow for programs to deal with regions of both _private_ and _shared_ kinds. When a region is allocated, we will use a bit in the region pointer to indicate whether the region is private. The bit can then be tested at allocation time to allow for cheaper allocation in many cases...

From a programmer's perspective, however, the task of modifying a program for the purpose of privatising regions is not an easy task...