### PR TITLE
Ultra-light-threads using Argobots 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -39,6 +39,13 @@ AC_ARG_WITH(
      ,
      )
 
+AC_ARG_WITH(
+     argobots,
+     AS_HELP_STRING(--with-argobpts[=ROOTDIR],[ARGOBOTS root-directory]),
+     AC_SUBST(ARGOBOTS_ROOT,${with_argobots})
+     ,
+     )
+
 AC_MSG_CHECKING(configure date)
 DATE=`date -u '+%Y-%m-%dT-%H:%M:%S'`
 AC_SUBST(DATE)

--- a/src/Compiler/Backend/BACKEND_INFO.sml
+++ b/src/Compiler/Backend/BACKEND_INFO.sml
@@ -47,6 +47,7 @@ signature BACKEND_INFO =
     val size_region_page : unit -> int  (* see also Region.h: REGION_PAGE_SIZE_BYTES *)
 
     val size_of_reg_desc : unit -> int  (* dependent on whether region profiling is enabled *)
+    val region_mutex_offset_words : unit -> int
 
     val finiteRegionDescSizeP : int     (* Number of words in a finite region
 					 * descriptor when profiling is used. *)

--- a/src/Compiler/Backend/CALC_OFFSET.sml
+++ b/src/Compiler/Backend/CALC_OFFSET.sml
@@ -7,7 +7,7 @@ signature CALC_OFFSET =
        and flush constructs.
     *)
 
-    type place 
+    type place
     type phsize
     type pp = int
     type lvar
@@ -38,11 +38,3 @@ signature CALC_OFFSET =
     val pr_atom   : Atom -> string
 
   end
-
-
-
-
-
-
-
-

--- a/src/Compiler/Backend/CalcOffset.sml
+++ b/src/Compiler/Backend/CalcOffset.sml
@@ -248,9 +248,14 @@ struct
 
         val size_ff0 = get_max_offset ()
         val size_cc = CallConv.get_cc_size cc
-(*        val () = print ("size_ff0: " ^ Int.toString size_ff0 ^ "; size_cc: " ^ Int.toString size_cc ^ "\n") *)
+(*
+        val () = print (Labels.pr_label lab ^ "size_ff0: " ^ Int.toString size_ff0
+                        ^ "; size_cc: " ^ Int.toString size_cc ^ "\n")
+        val () = print ("cc: " ^ CallConv.pr_cc cc ^ "\n")
+*)
         val size_ff = if (size_ff0 + size_cc) mod 2 = 0 then size_ff0 else size_ff0+1
-	val cc' = CallConv.add_frame_size(cc,size_ff)
+
+        val cc' = CallConv.add_frame_size(cc,size_ff)
       in
 	gen_fn(lab,cc',lss_co)
       end
@@ -514,7 +519,7 @@ struct
 	(* size_fd = size_cc + size_ff *)
 	val size_rcf = CallConv.get_rcf_size cc
 	val size_ccf = CallConv.get_ccf_size cc
-	val size_cc = CallConv.get_cc_size cc (* incl. return label *)
+	val size_cc = CallConv.get_cc_size cc (* incl. return address *)
 	val size_ff = CallConv.get_frame_size cc
 	val args_on_stack_cc = CallConv.get_spilled_args_with_offsets cc
 	val LVenv_cc = List.foldl (fn ((lv,offset),LVenv) => LvarFinMap.add(lv,offset+size_cc,LVenv))

--- a/src/Compiler/Backend/CallConv.sml
+++ b/src/Compiler/Backend/CallConv.sml
@@ -110,7 +110,7 @@ functor CallConv(BI : BACKEND_INFO) : CALL_CONV =
     fun get_cc_size cc =
         get_rcf_size cc +
         get_ccf_size cc +
-        1 (* The return label occupies one word on the stack. *)
+        1 (* The return address occupies one word on the stack. *)
 
     fun add_frame_size ({clos,args,reg_args,fargs,res,frame_size},f_size) =
         {clos = clos,

--- a/src/Compiler/Backend/ClosExp.sml
+++ b/src/Compiler/Backend/ClosExp.sml
@@ -1592,7 +1592,7 @@ struct
                let
                  val free_vars = remove_zero_sized_region_closure_lvars env free_vars_all
 
-                 val new_lab = fresh_lab (Labels.pr_label lab ^ ".anon")
+                 val new_lab = Labels.renew lab "anon"
                  val lv_clos = fresh_lvar("clos")
                  val args = List.map #1 pat
                  val ress = gen_fresh_res_lvars metaType (* Result variables are not bound in env as they only exists in cc *)

--- a/src/Compiler/Backend/X64/CodeGenUtilX64.sml
+++ b/src/Compiler/Backend/X64/CodeGenUtilX64.sml
@@ -865,9 +865,9 @@ struct
             copy(t,tmp_reg1,
             move_immed(IntInf.fromInt n, R tmp_reg0,     (*   tmp_reg0 = n                     *)
             I.jmp(L(NameLab "__allocate")) ::            (*   jmp to __allocate with args in   *)
-            maybe_update_alloc_period(
             I.lab l ::                                   (*     tmp_reg1 and tmp_reg0; result  *)
-            copy(tmp_reg1,t,C))))                        (*     in tmp_reg1.                   *)
+            maybe_update_alloc_period(                   (*     in tmp_reg1.                   *)
+            copy(tmp_reg1,t,C))))
           end
         else if parallelism_p() andalso not(par_alloc_unprotected_p()) then
           let val n = n0
@@ -908,9 +908,9 @@ struct
             I.pop (R rax) ::
             I.pop (R tmp_reg1) ::
             I.leaq(D(i2s(~8*n),tmp_reg0),R tmp_reg1) ::             (*   tmp_reg1 = tmp_reg0 - 8n         *)
-            maybe_update_alloc_period(
             I.lab l ::                                              (*     tmp_reg1 and tmp_reg0; result  *)
-            (copy(tmp_reg1,t,C))))))                                (*     in tmp_reg1.                   *)
+            maybe_update_alloc_period(                              (*     in tmp_reg1.                   *)
+            (copy(tmp_reg1,t,C))))))
           end
         else
           let val n = n0

--- a/src/Compiler/Backend/X64/CodeGenUtilX64.sml
+++ b/src/Compiler/Backend/X64/CodeGenUtilX64.sml
@@ -1230,12 +1230,14 @@ struct
       (* Compile Switch Statements *)
       local
         fun new_label str = new_local_lab str
-        fun label(lab,C) = I.lab lab :: C
-        fun jmp(lab,C) = I.jmp(L lab) :: rem_dead_code C
+        fun label (lab,C) = I.lab lab :: C
+        fun jmp (lab,C) = I.jmp(L lab) :: rem_dead_code C
         fun inline_cont C =
-          case C
-            of (i as I.jmp _) :: _ => SOME (fn C => i :: rem_dead_code C)
-             | _ => NONE
+            case C of
+                (i as I.jmp _) :: _ => SOME (fn C => i :: rem_dead_code C)
+              | (i as I.ret) :: _ => SOME (fn C => i :: rem_dead_code C)
+              | (i1 as I.leaq _) :: (i2 as I.ret) :: _ => SOME (fn C => i1 :: i2 :: rem_dead_code C)
+              | _ => NONE
       in
         fun binary_search (sels,
                            default,

--- a/src/Compiler/Backend/X64/CodeGenX64.sml
+++ b/src/Compiler/Backend/X64/CodeGenX64.sml
@@ -1235,7 +1235,7 @@ struct
                                                I.movq(R rdi, R tmp_reg0),
                                                I.push(I"0")                          (* push dummy - for 16-byte alignment *)
                                               ]
-                                            @ compile_c_call_prim("pthread_exit", [SS.PHREG_ATY tmp_reg0], NONE, size_ff (* not used *), tmp_reg1,
+                                            @ compile_c_call_prim("thread_exit", [SS.PHREG_ATY tmp_reg0], NONE, size_ff (* not used *), tmp_reg1,
                                               [I.addq(I "16", R rsp),                 (* adjust stack - for 16-byte alignment *)
                                                I.movq(I "0", R rax)]                 (* move result to %rax *)
                                             @ (map (fn r => I.pop (R r)) (List.rev callee_save_regs_ccall))

--- a/src/Compiler/Backend/X64/CodeGenX64.sml
+++ b/src/Compiler/Backend/X64/CodeGenX64.sml
@@ -712,7 +712,7 @@ struct
                   let
                     val (t_lab,f_lab) = if sel_val = IntInf.fromInt BI.ml_true then (lab_t,lab_f)
                                         else (lab_f,lab_t)
-                    val lab_exit = new_local_lab "lab_exit"
+                    val lab_exit = new_local_lab "done"
                   in
                     I.lab(LocalLab t_lab) ::
                     CG_lss(lss,size_ff,size_ccf,
@@ -753,7 +753,7 @@ struct
                                C @ I.lab(LocalLab f_lab) ::
                                CG_lss(default,size_ff,size_ccf, C'))
                       | NONE =>
-                        let val lab_exit = new_local_lab "lab_exit"
+                        let val lab_exit = new_local_lab "done"
                         in I.lab(LocalLab t_lab) ::
                            CG_lss(lss,size_ff,size_ccf,
                                   I.jmp(L lab_exit) ::
@@ -1005,26 +1005,26 @@ struct
                             | Int_to_f64     => int_to_f64 arg
                             | Blockf64_size  => blockf64_size arg
 
-                            | Is_null => cmpi_kill_tmp01 {box=false,quad=false} I.je
-                                                         (x, SS.INTEGER_ATY{value=IntInf.fromInt 0,
-                                                                            precision=32},d,size_ff,C)
+                            | Is_null => cmpi_kill_tmp01_cmov {box=false,quad=false} I.cmoveq
+                                                              (x, SS.INTEGER_ATY{value=IntInf.fromInt 0,
+                                                                                 precision=32},d,size_ff,C)
                             | _ => die ("unsupported prim with 1 arg: " ^ PrimName.pp_prim name)
                        end
                      | [x,y] =>
                        let val arg = (x,y,d,size_ff,C)
                        in case name of
-                              Equal_int32ub =>  cmpi_kill_tmp01 {box=false, quad=false} I.je arg
-                            | Equal_int32b =>   cmpi_kill_tmp01 {box=true,  quad=false} I.je arg
-                            | Equal_int31 =>    cmpi_kill_tmp01 {box=false, quad=false} I.je arg
-                            | Equal_word31 =>   cmpi_kill_tmp01 {box=false, quad=false} I.je arg
-                            | Equal_word32ub => cmpi_kill_tmp01 {box=false, quad=false} I.je arg
-                            | Equal_word32b =>  cmpi_kill_tmp01 {box=true,  quad=false} I.je arg
-                            | Equal_int64ub =>  cmpi_kill_tmp01 {box=false, quad=true}  I.je arg
-                            | Equal_int64b =>   cmpi_kill_tmp01 {box=true,  quad=true}  I.je arg
-                            | Equal_int63 =>    cmpi_kill_tmp01 {box=false, quad=true}  I.je arg
-                            | Equal_word63 =>   cmpi_kill_tmp01 {box=false, quad=true}  I.je arg
-                            | Equal_word64ub => cmpi_kill_tmp01 {box=false, quad=true}  I.je arg
-                            | Equal_word64b =>  cmpi_kill_tmp01 {box=true,  quad=true}  I.je arg
+                              Equal_int32ub =>  cmpi_kill_tmp01_cmov {box=false, quad=false} I.cmoveq arg
+                            | Equal_int32b =>   cmpi_kill_tmp01_cmov {box=true,  quad=false} I.cmoveq arg
+                            | Equal_int31 =>    cmpi_kill_tmp01_cmov {box=false, quad=false} I.cmoveq arg
+                            | Equal_word31 =>   cmpi_kill_tmp01_cmov {box=false, quad=false} I.cmoveq arg
+                            | Equal_word32ub => cmpi_kill_tmp01_cmov {box=false, quad=false} I.cmoveq arg
+                            | Equal_word32b =>  cmpi_kill_tmp01_cmov {box=true,  quad=false} I.cmoveq arg
+                            | Equal_int64ub =>  cmpi_kill_tmp01_cmov {box=false, quad=true}  I.cmoveq arg
+                            | Equal_int64b =>   cmpi_kill_tmp01_cmov {box=true,  quad=true}  I.cmoveq arg
+                            | Equal_int63 =>    cmpi_kill_tmp01_cmov {box=false, quad=true}  I.cmoveq arg
+                            | Equal_word63 =>   cmpi_kill_tmp01_cmov {box=false, quad=true}  I.cmoveq arg
+                            | Equal_word64ub => cmpi_kill_tmp01_cmov {box=false, quad=true}  I.cmoveq arg
+                            | Equal_word64b =>  cmpi_kill_tmp01_cmov {box=true,  quad=true}  I.cmoveq arg
 
                             | Plus_int32ub =>  add_num_kill_tmp01 {ovf=true,  tag=false, quad=false} arg
                             | Plus_int31 =>    add_num_kill_tmp01 {ovf=true,  tag=true,  quad=false} arg
@@ -1060,69 +1060,69 @@ struct
                             | Abs_int64b => abs_int_boxed_kill_tmp0 {quad=true} arg
                             | Abs_real =>   absf_kill_tmp01 arg
 
-                            | Less_int32ub =>  cmpi_kill_tmp01 {box=false, quad=false} I.jl arg
-                            | Less_int32b =>   cmpi_kill_tmp01 {box=true,  quad=false} I.jl arg
-                            | Less_int31 =>    cmpi_kill_tmp01 {box=false, quad=false} I.jl arg
-                            | Less_word31 =>   cmpi_kill_tmp01 {box=false, quad=false} I.jb arg
-                            | Less_word32ub => cmpi_kill_tmp01 {box=false, quad=false} I.jb arg
-                            | Less_word32b =>  cmpi_kill_tmp01 {box=true,  quad=false} I.jb arg
-                            | Less_int64ub =>  cmpi_kill_tmp01 {box=false, quad=true}  I.jl arg
-                            | Less_int64b =>   cmpi_kill_tmp01 {box=true,  quad=true}  I.jl arg
-                            | Less_int63 =>    cmpi_kill_tmp01 {box=false, quad=true}  I.jl arg
-                            | Less_word63 =>   cmpi_kill_tmp01 {box=false, quad=true}  I.jb arg
-                            | Less_word64ub => cmpi_kill_tmp01 {box=false, quad=true}  I.jb arg
-                            | Less_word64b =>  cmpi_kill_tmp01 {box=true,  quad=true}  I.jb arg
+                            | Less_int32ub =>  cmpi_kill_tmp01_cmov {box=false, quad=false} I.cmovlq arg
+                            | Less_int32b =>   cmpi_kill_tmp01_cmov {box=true,  quad=false} I.cmovlq arg
+                            | Less_int31 =>    cmpi_kill_tmp01_cmov {box=false, quad=false} I.cmovlq arg
+                            | Less_word31 =>   cmpi_kill_tmp01_cmov {box=false, quad=false} I.cmovbq arg
+                            | Less_word32ub => cmpi_kill_tmp01_cmov {box=false, quad=false} I.cmovbq arg
+                            | Less_word32b =>  cmpi_kill_tmp01_cmov {box=true,  quad=false} I.cmovbq arg
+                            | Less_int64ub =>  cmpi_kill_tmp01_cmov {box=false, quad=true}  I.cmovlq arg
+                            | Less_int64b =>   cmpi_kill_tmp01_cmov {box=true,  quad=true}  I.cmovlq arg
+                            | Less_int63 =>    cmpi_kill_tmp01_cmov {box=false, quad=true}  I.cmovlq arg
+                            | Less_word63 =>   cmpi_kill_tmp01_cmov {box=false, quad=true}  I.cmovbq arg
+                            | Less_word64ub => cmpi_kill_tmp01_cmov {box=false, quad=true}  I.cmovbq arg
+                            | Less_word64b =>  cmpi_kill_tmp01_cmov {box=true,  quad=true}  I.cmovbq arg
 
-                            | Less_real => cmpf_kill_tmp01 LESSTHAN arg
-                            | Less_f64 =>  cmpf64_kill_tmp0 LESSTHAN arg
+                            | Less_real => cmpf_kill_tmp01_cmov I.cmovbq arg
+                            | Less_f64 => cmpf64_kill_tmp01_cmov I.cmovbq arg
 
-                            | Lesseq_int32ub =>  cmpi_kill_tmp01 {box=false, quad=false} I.jle arg
-                            | Lesseq_int32b =>   cmpi_kill_tmp01 {box=true,  quad=false} I.jle arg
-                            | Lesseq_int31 =>    cmpi_kill_tmp01 {box=false, quad=false} I.jle arg
-                            | Lesseq_word31 =>   cmpi_kill_tmp01 {box=false, quad=false} I.jbe arg
-                            | Lesseq_word32ub => cmpi_kill_tmp01 {box=false, quad=false} I.jbe arg
-                            | Lesseq_word32b =>  cmpi_kill_tmp01 {box=true,  quad=false} I.jbe arg
-                            | Lesseq_int64ub =>  cmpi_kill_tmp01 {box=false, quad=true}  I.jle arg
-                            | Lesseq_int64b =>   cmpi_kill_tmp01 {box=true,  quad=true}  I.jle arg
-                            | Lesseq_int63 =>    cmpi_kill_tmp01 {box=false, quad=true}  I.jle arg
-                            | Lesseq_word63 =>   cmpi_kill_tmp01 {box=false, quad=true}  I.jbe arg
-                            | Lesseq_word64ub => cmpi_kill_tmp01 {box=false, quad=true}  I.jbe arg
-                            | Lesseq_word64b =>  cmpi_kill_tmp01 {box=true,  quad=true}  I.jbe arg
+                            | Lesseq_int32ub =>  cmpi_kill_tmp01_cmov {box=false, quad=false} I.cmovleq arg
+                            | Lesseq_int32b =>   cmpi_kill_tmp01_cmov {box=true,  quad=false} I.cmovleq arg
+                            | Lesseq_int31 =>    cmpi_kill_tmp01_cmov {box=false, quad=false} I.cmovleq arg
+                            | Lesseq_word31 =>   cmpi_kill_tmp01_cmov {box=false, quad=false} I.cmovbeq arg
+                            | Lesseq_word32ub => cmpi_kill_tmp01_cmov {box=false, quad=false} I.cmovbeq arg
+                            | Lesseq_word32b =>  cmpi_kill_tmp01_cmov {box=true,  quad=false} I.cmovbeq arg
+                            | Lesseq_int64ub =>  cmpi_kill_tmp01_cmov {box=false, quad=true}  I.cmovleq arg
+                            | Lesseq_int64b =>   cmpi_kill_tmp01_cmov {box=true,  quad=true}  I.cmovleq arg
+                            | Lesseq_int63 =>    cmpi_kill_tmp01_cmov {box=false, quad=true}  I.cmovleq arg
+                            | Lesseq_word63 =>   cmpi_kill_tmp01_cmov {box=false, quad=true}  I.cmovbeq arg
+                            | Lesseq_word64ub => cmpi_kill_tmp01_cmov {box=false, quad=true}  I.cmovbeq arg
+                            | Lesseq_word64b =>  cmpi_kill_tmp01_cmov {box=true,  quad=true}  I.cmovbeq arg
 
-                            | Lesseq_real => cmpf_kill_tmp01 LESSEQUAL arg
-                            | Lesseq_f64 =>  cmpf64_kill_tmp0 LESSEQUAL arg
+                            | Lesseq_real => cmpf_kill_tmp01_cmov I.cmovbeq arg
+                            | Lesseq_f64 => cmpf64_kill_tmp01_cmov I.cmovbeq arg
 
-                            | Greater_int32ub =>  cmpi_kill_tmp01 {box=false, quad=false} I.jg arg
-                            | Greater_int32b =>   cmpi_kill_tmp01 {box=true,  quad=false} I.jg arg
-                            | Greater_int31 =>    cmpi_kill_tmp01 {box=false, quad=false} I.jg arg
-                            | Greater_word31 =>   cmpi_kill_tmp01 {box=false, quad=false} I.ja arg
-                            | Greater_word32ub => cmpi_kill_tmp01 {box=false, quad=false} I.ja arg
-                            | Greater_word32b =>  cmpi_kill_tmp01 {box=true,  quad=false} I.ja arg
-                            | Greater_int64ub =>  cmpi_kill_tmp01 {box=false, quad=true}  I.jg arg
-                            | Greater_int64b =>   cmpi_kill_tmp01 {box=true,  quad=true}  I.jg arg
-                            | Greater_int63 =>    cmpi_kill_tmp01 {box=false, quad=true}  I.jg arg
-                            | Greater_word63 =>   cmpi_kill_tmp01 {box=false, quad=true}  I.ja arg
-                            | Greater_word64ub => cmpi_kill_tmp01 {box=false, quad=true}  I.ja arg
-                            | Greater_word64b =>  cmpi_kill_tmp01 {box=true,  quad=true}  I.ja arg
+                            | Greater_int32ub =>  cmpi_kill_tmp01_cmov {box=false, quad=false} I.cmovgq arg
+                            | Greater_int32b =>   cmpi_kill_tmp01_cmov {box=true,  quad=false} I.cmovgq arg
+                            | Greater_int31 =>    cmpi_kill_tmp01_cmov {box=false, quad=false} I.cmovgq arg
+                            | Greater_word31 =>   cmpi_kill_tmp01_cmov {box=false, quad=false} I.cmovaq arg
+                            | Greater_word32ub => cmpi_kill_tmp01_cmov {box=false, quad=false} I.cmovaq arg
+                            | Greater_word32b =>  cmpi_kill_tmp01_cmov {box=true,  quad=false} I.cmovaq arg
+                            | Greater_int64ub =>  cmpi_kill_tmp01_cmov {box=false, quad=true}  I.cmovgq arg
+                            | Greater_int64b =>   cmpi_kill_tmp01_cmov {box=true,  quad=true}  I.cmovgq arg
+                            | Greater_int63 =>    cmpi_kill_tmp01_cmov {box=false, quad=true}  I.cmovgq arg
+                            | Greater_word63 =>   cmpi_kill_tmp01_cmov {box=false, quad=true}  I.cmovaq arg
+                            | Greater_word64ub => cmpi_kill_tmp01_cmov {box=false, quad=true}  I.cmovaq arg
+                            | Greater_word64b =>  cmpi_kill_tmp01_cmov {box=true,  quad=true}  I.cmovaq arg
 
-                            | Greater_real => cmpf_kill_tmp01 GREATERTHAN arg
-                            | Greater_f64 =>  cmpf64_kill_tmp0 GREATERTHAN arg
+                            | Greater_real => cmpf_kill_tmp01_cmov I.cmovaq arg
+                            | Greater_f64 => cmpf64_kill_tmp01_cmov I.cmovaq arg
 
-                            | Greatereq_int32ub =>  cmpi_kill_tmp01 {box=false, quad=false} I.jge arg
-                            | Greatereq_int32b =>   cmpi_kill_tmp01 {box=true,  quad=false} I.jge arg
-                            | Greatereq_int31 =>    cmpi_kill_tmp01 {box=false, quad=false} I.jge arg
-                            | Greatereq_word31 =>   cmpi_kill_tmp01 {box=false, quad=false} I.jae arg
-                            | Greatereq_word32ub => cmpi_kill_tmp01 {box=false, quad=false} I.jae arg
-                            | Greatereq_word32b =>  cmpi_kill_tmp01 {box=true,  quad=false} I.jae arg
-                            | Greatereq_int64ub =>  cmpi_kill_tmp01 {box=false, quad=true}  I.jge arg
-                            | Greatereq_int64b =>   cmpi_kill_tmp01 {box=true,  quad=true}  I.jge arg
-                            | Greatereq_int63 =>    cmpi_kill_tmp01 {box=false, quad=true}  I.jge arg
-                            | Greatereq_word63 =>   cmpi_kill_tmp01 {box=false, quad=true}  I.jae arg
-                            | Greatereq_word64ub => cmpi_kill_tmp01 {box=false, quad=true}  I.jae arg
-                            | Greatereq_word64b =>  cmpi_kill_tmp01 {box=true,  quad=true}  I.jae arg
+                            | Greatereq_int32ub =>  cmpi_kill_tmp01_cmov {box=false, quad=false} I.cmovgeq arg
+                            | Greatereq_int32b =>   cmpi_kill_tmp01_cmov {box=true,  quad=false} I.cmovgeq arg
+                            | Greatereq_int31 =>    cmpi_kill_tmp01_cmov {box=false, quad=false} I.cmovgeq arg
+                            | Greatereq_word31 =>   cmpi_kill_tmp01_cmov {box=false, quad=false} I.cmovaeq arg
+                            | Greatereq_word32ub => cmpi_kill_tmp01_cmov {box=false, quad=false} I.cmovaeq arg
+                            | Greatereq_word32b =>  cmpi_kill_tmp01_cmov {box=true,  quad=false} I.cmovaeq arg
+                            | Greatereq_int64ub =>  cmpi_kill_tmp01_cmov {box=false, quad=true}  I.cmovgeq arg
+                            | Greatereq_int64b =>   cmpi_kill_tmp01_cmov {box=true,  quad=true}  I.cmovgeq arg
+                            | Greatereq_int63 =>    cmpi_kill_tmp01_cmov {box=false, quad=true}  I.cmovgeq arg
+                            | Greatereq_word63 =>   cmpi_kill_tmp01_cmov {box=false, quad=true}  I.cmovaeq arg
+                            | Greatereq_word64ub => cmpi_kill_tmp01_cmov {box=false, quad=true}  I.cmovaeq arg
+                            | Greatereq_word64b =>  cmpi_kill_tmp01_cmov {box=true,  quad=true}  I.cmovaeq arg
 
-                            | Greatereq_real => cmpf_kill_tmp01 GREATEREQUAL arg
-                            | Greatereq_f64 =>  cmpf64_kill_tmp0 GREATEREQUAL arg
+                            | Greatereq_real => cmpf_kill_tmp01_cmov I.cmovaeq arg
+                            | Greatereq_f64 => cmpf64_kill_tmp01_cmov I.cmovaeq arg
 
                             | Andb_word31 =>   andb_word_kill_tmp01 {quad=false} arg
                             | Andb_word32ub => andb_word_kill_tmp01 {quad=false} arg
@@ -1597,10 +1597,10 @@ val _ = List.app (fn lab => print ("\n" ^ (I.pr_lab lab))) (List.rev dat_labs)
         fun allocinreg C =
             if not(parallelism_p()) then C
             else
-            let val allocinreg_protect = new_local_lab "allocinreg_protect"
+            let val allocinreg_protect = new_local_lab "alloc_protect"
                 val mutex_offset_bytes = i2s (8*BackendInfo.region_mutex_offset_words())
-                val l_expand = new_local_lab "alloc_expand"
-                val l_expand_protect = new_local_lab "alloc_expand_protect"
+                val l_expand = new_local_lab "expand"
+                val l_expand_protect = new_local_lab "protect"
                 fun mk_expand_protect C =
                     I.lab l_expand_protect ::                 (* expand_protect:                    *)
                     I.pop(R I.rax) ::                         (*   restore rax                      *)

--- a/src/Compiler/Backend/X64/ExecutionX64.sml
+++ b/src/Compiler/Backend/X64/ExecutionX64.sml
@@ -163,6 +163,14 @@ structure ExecutionX64: EXECUTION =
 
     val par_alloc_unprotected_p = Flags.is_on0 "parallelism_alloc_unprotected"
 
+    val _ = Flags.add_bool_entry
+	{long="argobots", short=SOME "argo", neg=false,
+	 menu=["Control","use the Argobots lightweight thread library"], item=ref false,
+	 desc="When enabled, executables link with the Argobots\n\
+              \lightweight thread library."}
+
+    val argobots_p = Flags.is_on0 "argobots"
+
     local val default = ""
     in
 	val _ = Flags.add_string_entry
@@ -314,6 +322,7 @@ structure ExecutionX64: EXECUTION =
                    die "parallelism enabled - turn off prof"
                  else if tag_pairs_p() then
                    die "parallelism enabled - turn off pair tagging"
+                 else if argobots_p() then "runtimeSystemArPar.a"
                  else "runtimeSystemPar.a")
               else
 	      if !region_profiling andalso gc_p() andalso tag_pairs_p() then "runtimeSystemGCTPProf.a"  else

--- a/src/Compiler/Backend/X64/ExecutionX64.sml
+++ b/src/Compiler/Backend/X64/ExecutionX64.sml
@@ -9,17 +9,17 @@ structure ExecutionX64: EXECUTION =
       BackendInfo(val down_growing_stack : bool = true)          (* true for x64 code generation *)
 
     structure NativeCompile = NativeCompile(structure BackendInfo = BackendInfo
-					    structure RegisterInfo = InstsX64.RI)
+                                            structure RegisterInfo = InstsX64.RI)
 
     structure CompileBasis = CompileBasis(structure ClosExp = NativeCompile.ClosExp)
 
     structure JumpTables = JumpTables(BackendInfo)
 
     structure CodeGen = CodeGenX64(structure BackendInfo = BackendInfo
-				   structure JumpTables = JumpTables
-				   structure CallConv = NativeCompile.CallConv
-				   structure LineStmt = NativeCompile.LineStmt
-				   structure SubstAndSimplify = NativeCompile.SubstAndSimplify)
+                                   structure JumpTables = JumpTables
+                                   structure CallConv = NativeCompile.CallConv
+                                   structure LineStmt = NativeCompile.LineStmt
+                                   structure SubstAndSimplify = NativeCompile.SubstAndSimplify)
 
     fun die s = Crash.impossible("ExecutionX64." ^ s)
 
@@ -28,156 +28,156 @@ structure ExecutionX64: EXECUTION =
     val be_rigid = false
 
     local
-	fun convertList option s =
-	    let val l = String.tokens(fn c => c = #",")s
-	    in map (fn s => option ^ s) l
-	    end
+        fun convertList option s =
+            let val l = String.tokens(fn c => c = #",")s
+            in map (fn s => option ^ s) l
+            end
     in
-	fun libConvertList s = concat(convertList " -l" s)
-	fun libdirsConvertList s = concat(convertList " -L" s)
+        fun libConvertList s = concat(convertList " -l" s)
+        fun libdirsConvertList s = concat(convertList " -L" s)
     end
 
     local val default = "m,c,dl"
     in
-	val _ = Flags.add_string_entry
-	    {long="libs", short=NONE, item=ref default,
-	     menu=["Control", "foreign libraries (archives)"],
-	     desc="For accessing a foreign function residing in\n\
-	      \an archive named libNAME.a from Standard ML code\n\
-	      \(using prim), you need to add 'NAME' to this\n\
-	      \comma-separated list. Notice that an object file\n\
-	      \(with extension '.o') is an archive if it is\n\
-	      \renamed to have extension '.a'. You may need to\n\
-	      \use the -libdirs option for specifying\n\
-	      \directories for which ld should look for library\n\
-	      \archives. The libraries are passed to 'ld' using\n\
-	      \the -l option."}
+        val _ = Flags.add_string_entry
+            {long="libs", short=NONE, item=ref default,
+             menu=["Control", "foreign libraries (archives)"],
+             desc="For accessing a foreign function residing in\n\
+              \an archive named libNAME.a from Standard ML code\n\
+              \(using prim), you need to add 'NAME' to this\n\
+              \comma-separated list. Notice that an object file\n\
+              \(with extension '.o') is an archive if it is\n\
+              \renamed to have extension '.a'. You may need to\n\
+              \use the -libdirs option for specifying\n\
+              \directories for which ld should look for library\n\
+              \archives. The libraries are passed to 'ld' using\n\
+              \the -l option."}
     end
 
     val _ = Flags.add_string_entry
       {long="libdirs", short=NONE, item=ref "",
        menu=["Control", "library directories (paths to archives)"],
        desc="This option controls where ld looks for\n\
-	\archives. The format is a comma-separated list\n\
-	\of directories; see the -libs entry. The default\n\
-	\is the empty list; thus 'ld' will look for\n\
-	\libraries in only the system specific default\n\
-	\directores. The directories are passed to 'ld'\n\
-	\using the -L option."}
+        \archives. The format is a comma-separated list\n\
+        \of directories; see the -libs entry. The default\n\
+        \is the empty list; thus 'ld' will look for\n\
+        \libraries in only the system specific default\n\
+        \directores. The directories are passed to 'ld'\n\
+        \using the -L option."}
 
     val _ = Flags.add_string_entry
-	let val macgcc = "gcc -Wl,-no_pie,-stack_size,0x10000000,-stack_addr,0xc0000000"
-	    val gcc = if onmac_p() then macgcc
-		      else "gcc -no-pie"
-	in
-	    {long="c_compiler", short=SOME "cc", item=ref gcc,
-	     menu=["Control", "C compiler (used for linking)"],
-	     desc="This option specifies which C compiler is\n\
-		  \used for linking. When linking with c++\n\
-		  \libraries, 'g++' is the linker you want.\n\
-		  \On Linux the default is 'gcc -no-pie',\n\
+        let val macgcc = "gcc -Wl,-no_pie,-stack_size,0x10000000,-stack_addr,0xc0000000"
+            val gcc = if onmac_p() then macgcc
+                      else "gcc -no-pie"
+        in
+            {long="c_compiler", short=SOME "cc", item=ref gcc,
+             menu=["Control", "C compiler (used for linking)"],
+             desc="This option specifies which C compiler is\n\
+                  \used for linking. When linking with c++\n\
+                  \libraries, 'g++' is the linker you want.\n\
+                  \On Linux the default is 'gcc -no-pie',\n\
                   \whereas on macOS, the default is\n\
                   \'" ^ macgcc ^ "'."}
-	end
+        end
 
     val _ = Flags.add_string_entry
-	let val mac_as = "as -q" (* "gcc -c -no-integrated-as" *)
+        let val mac_as = "as -q" (* "gcc -c -no-integrated-as" *)
             val linux_as = "as --64"
-	    val ass = if onmac_p() then mac_as else linux_as
-	in
-	    {long="assembler", short=SOME "as", item=ref ass,
-	     menu=["Control", "Assembler command"],
-	     desc="This option specifies the assembler used.\n\
-		  \On Linux the default is '" ^ linux_as ^ "'. On macOS,\n\
+            val ass = if onmac_p() then mac_as else linux_as
+        in
+            {long="assembler", short=SOME "as", item=ref ass,
+             menu=["Control", "Assembler command"],
+             desc="This option specifies the assembler used.\n\
+                  \On Linux the default is '" ^ linux_as ^ "'. On macOS,\n\
                   \the default is '" ^ mac_as ^ "'."}
-	end
+        end
 
     val strip_p = ref false
     val _ = Flags.add_bool_entry
        {long="strip", short=NONE, neg=false, item=strip_p,
-	menu=["Control", "strip executable"],
-	desc="If enabled, the Kit strips the generated executable."}
+        menu=["Control", "strip executable"],
+        desc="If enabled, the Kit strips the generated executable."}
 
     val _ = Flags.add_bool_entry
        {long="delete_target_files", short=NONE, neg=true, item=ref true,
-	menu=["Debug", "delete target files"],
-	desc="Delete assembler files produced by the compiler. If you\n\
-	 \disable this flag, you can inspect the assembler code\n\
-	 \produced by the compiler."}
+        menu=["Debug", "delete target files"],
+        desc="Delete assembler files produced by the compiler. If you\n\
+         \disable this flag, you can inspect the assembler code\n\
+         \produced by the compiler."}
 
     local
       val desc =
           "When enabled, the compiler passes the option --gstabs\n\
-	  \to `as' (The GNU Assembler) and preserves the generated\n\
-	  \assembler files (.s files). Passing the --gstabs\n\
-	  \option to `as' makes it possible to step through\n\
-	  \the generated program using gdb (The GNU Debugger)."
+          \to `as' (The GNU Assembler) and preserves the generated\n\
+          \assembler files (.s files). Passing the --gstabs\n\
+          \option to `as' makes it possible to step through\n\
+          \the generated program using gdb (The GNU Debugger)."
       val desc_darwin =
           "When enabled, the compiler passes the option --g\n\
-	  \to `as' (The GNU Assembler) and preserves the generated\n\
-	  \assembler files (.s files). Passing the --g\n\
-	  \option to `as' makes it possible to step through\n\
-	  \the generated program using gdb (The GNU Debugger)."
+          \to `as' (The GNU Assembler) and preserves the generated\n\
+          \assembler files (.s files). Passing the --g\n\
+          \option to `as' makes it possible to step through\n\
+          \the generated program using gdb (The GNU Debugger)."
     in
       val _ = Flags.add_bool_entry
-	{long="gdb_support", short=SOME "g", neg=false,
-	 menu=["Debug","gdb support"], item=ref false,
-	 desc=if onmac_p() then desc_darwin else desc}
+        {long="gdb_support", short=SOME "g", neg=false,
+         menu=["Debug","gdb support"], item=ref false,
+         desc=if onmac_p() then desc_darwin else desc}
     end
 
     val dangle_stat_p = ref false
     val _ = Flags.add_bool_entry
-	{long="dangling_pointers_statistics", short=NONE, neg=false,
-	 menu=["Debug","dangling pointers statistics"], item=dangle_stat_p,
-	 desc="When enabled, the compiler prints statistics about\n\
+        {long="dangling_pointers_statistics", short=NONE, neg=false,
+         menu=["Debug","dangling pointers statistics"], item=dangle_stat_p,
+         desc="When enabled, the compiler prints statistics about\n\
           \the number of times strengthening of the region typing\n\
-	  \rules (to avoid dangling pointers during evaluation)\n\
-	  \effects the target program. This flag is useful only\n\
-	  \when the flag -gc or -no_dangle is enabled."}
+          \rules (to avoid dangling pointers during evaluation)\n\
+          \effects the target program. This flag is useful only\n\
+          \when the flag -gc or -no_dangle is enabled."}
 
-    fun report_dangle_stat() =
-	 if !dangle_stat_p then
-	   let val n = !Flags.Statistics.no_dangling_pointers_changes
+    fun report_dangle_stat () =
+         if !dangle_stat_p then
+           let val n = !Flags.Statistics.no_dangling_pointers_changes
                val total = !Flags.Statistics.no_dangling_pointers_changes_total
-	   in
-	       print ("Dangling pointers statistics: \n\
-		      \ * Number of changes due to strengthening of typing \n\
-		      \   rules to avoid dangling pointers: " ^ Int.toString n ^
-		      "\n * Total number of changes: " ^ Int.toString total ^ "\n")
-	   end
-	 else ()
+           in
+               print ("Dangling pointers statistics: \n\
+                      \ * Number of changes due to strengthening of typing \n\
+                      \   rules to avoid dangling pointers: " ^ Int.toString n ^
+                      "\n * Total number of changes: " ^ Int.toString total ^ "\n")
+           end
+         else ()
 
     val _ = Flags.add_bool_entry
-	{long="parallelism", short=SOME "par", neg=false,
-	 menu=["Control","parallelism"], item=ref false,
-	 desc="When enabled, the runtime system supports\n\
+        {long="parallelism", short=SOME "par", neg=false,
+         menu=["Control","parallelism"], item=ref false,
+         desc="When enabled, the runtime system supports\n\
           \parallel threads."}
 
     val parallelism_p = Flags.is_on0 "parallelism"
 
     val _ = Flags.add_bool_entry
-	{long="parallelism_alloc_unprotected", short=SOME "par0", neg=false,
-	 menu=["Control","parallelism allocation unprotected"], item=ref false,
-	 desc="When enabled, allocation into a region is not\n\
+        {long="parallelism_alloc_unprotected", short=SOME "par0", neg=false,
+         menu=["Control","parallelism allocation unprotected"], item=ref false,
+         desc="When enabled, allocation into a region is not\n\
           \guaranteed to be atomic."}
 
     val par_alloc_unprotected_p = Flags.is_on0 "parallelism_alloc_unprotected"
 
     val _ = Flags.add_bool_entry
-	{long="argobots", short=SOME "argo", neg=false,
-	 menu=["Control","use the Argobots lightweight thread library"], item=ref false,
-	 desc="When enabled, executables link with the Argobots\n\
+        {long="argobots", short=SOME "argo", neg=false,
+         menu=["Control","use the Argobots lightweight thread library"], item=ref false,
+         desc="When enabled, executables link with the Argobots\n\
               \lightweight thread library."}
 
     val argobots_p = Flags.is_on0 "argobots"
 
     local val default = ""
     in
-	val _ = Flags.add_string_entry
-	    {long="mlb-subdir", short=NONE, item=ref default,
-	     menu=["Control", "Use MLB subdir-postfix"],
-	     desc="For ensuring that the smart recompilation scheme\n\
-	      \is not reusing target-code compiled with different\n\
+        val _ = Flags.add_string_entry
+            {long="mlb-subdir", short=NONE, item=ref default,
+             menu=["Control", "Use MLB subdir-postfix"],
+             desc="For ensuring that the smart recompilation scheme\n\
+              \is not reusing target-code compiled with different\n\
               \settings, a string provided with the mlb-subdir\n\
               \option can ensure the use of consistently generated\n\
               \code. This option is Useful, in particular, when\n\
@@ -199,7 +199,7 @@ structure ExecutionX64: EXECUTION =
     val pr_lab = Labels.pr_label
 
     type linkinfo = {code_label:lab, imports: lab list * lab list,
-		     exports : lab list * lab list, unsafe:bool}
+                     exports : lab list * lab list, unsafe:bool}
     fun code_label_of_linkinfo (li:linkinfo) = #code_label li
     fun exports_of_linkinfo (li:linkinfo) = #exports li
     fun imports_of_linkinfo (li:linkinfo) = #imports li
@@ -220,21 +220,21 @@ structure ExecutionX64: EXECUTION =
     fun compile fe (ce, CB, strdecs, vcg_file) =
       let val (cb,closenv) = CompileBasis.de_CompileBasis CB
       in
-	case Compile.compile fe (ce, cb, strdecs)
-	  of Compile.CEnvOnlyRes ce => CEnvOnlyRes ce
-	   | Compile.CodeRes(ce,cb,target,safe) =>
-	    let
-	      val (closenv, target_new) = NativeCompile.compile(closenv,target,safe,vcg_file)
-	      val {main_lab, code, imports, exports, safe} = target_new
-	      val asm_prg = Timing.timing "CG" CodeGen.CG target_new
-	      val linkinfo = mk_linkinfo {code_label=main_lab,
-					  imports=imports, (* (MLFunLab, DatLab) *)
-					  exports=exports, (* (MLFunLab, DatLab) *)
-					  unsafe=not(safe)}
-	      val CB = CompileBasis.mk_CompileBasis(cb,closenv)
-	    in
-	      CodeRes(ce,CB,asm_prg,linkinfo)
-	    end
+        case Compile.compile fe (ce, cb, strdecs)
+          of Compile.CEnvOnlyRes ce => CEnvOnlyRes ce
+           | Compile.CodeRes(ce,cb,target,safe) =>
+            let
+              val (closenv, target_new) = NativeCompile.compile(closenv,target,safe,vcg_file)
+              val {main_lab, code, imports, exports, safe} = target_new
+              val asm_prg = Timing.timing "CG" CodeGen.CG target_new
+              val linkinfo = mk_linkinfo {code_label=main_lab,
+                                          imports=imports, (* (MLFunLab, DatLab) *)
+                                          exports=exports, (* (MLFunLab, DatLab) *)
+                                          unsafe=not(safe)}
+              val CB = CompileBasis.mk_CompileBasis(cb,closenv)
+            in
+              CodeRes(ce,CB,asm_prg,linkinfo)
+            end
       end
     val generate_link_code = SOME (fn (labs,exports) => CodeGen.generate_link_code (labs,exports))
 
@@ -256,13 +256,13 @@ structure ExecutionX64: EXECUTION =
     fun gas0() =
         !(Flags.lookup_string_entry "assembler")
 (*
-	if onmac_p() then "as -arch x64" else "as --64"
+        if onmac_p() then "as -arch x64" else "as --64"
 *)
 
     fun gas() = if gdb_support() then
                   if onmac_p() then gas0() ^ " -g"
                   else gas0() ^ " --gstabs"
-		else gas0()
+                else gas0()
 
     fun assemble (file_s, file_o) =
       (execute_command (gas() ^ " -o " ^ file_o ^ " " ^ file_s);
@@ -271,47 +271,47 @@ structure ExecutionX64: EXECUTION =
 
     fun emit {target, filename:string} : string =
       let val filename_o = filename ^ ".o"
-	  val filename_s = filename ^ ".s"
+          val filename_s = filename ^ ".s"
       in CodeGen.emit (target, filename_s);
-	assemble(filename_s, filename_o);
-	filename_o
+        assemble(filename_s, filename_o);
+        filename_o
       end
 
     fun strip run =
       if !strip_p then (execute_command ("strip " ^ run)
-	                handle _ => ())
+                        handle _ => ())
       else ()
 
     fun link_files_with_runtime_system0 path_to_runtime files run =
       let val files = map (fn s => s ^ " ") files
-	  val libdirs =
-	      case !(Flags.lookup_string_entry "libdirs") of
-		  "" => ""
-		| libdirs => " " ^ libdirsConvertList libdirs
+          val libdirs =
+              case !(Flags.lookup_string_entry "libdirs") of
+                  "" => ""
+                | libdirs => " " ^ libdirsConvertList libdirs
 
           val pthread = if parallelism_p() andalso not(onmac_p())
                         then " -pthread"
                         else ""
           val cc = !(Flags.lookup_string_entry "c_compiler")
-	  val shell_cmd = cc ^ " -o " ^ run ^ " " ^
-	    concat files ^ path_to_runtime() ^ libdirs ^ libConvertList(!libs) ^ pthread
+          val shell_cmd = cc ^ " -o " ^ run ^ " " ^
+            concat files ^ path_to_runtime() ^ libdirs ^ libConvertList(!libs) ^ pthread
       in
-	execute_command shell_cmd;
-	strip run;
-	print("[wrote executable file:\t" ^ run ^ "]\n");
-	report_dangle_stat()
+        execute_command shell_cmd;
+        strip run;
+        print("[wrote executable file:\t" ^ run ^ "]\n");
+        report_dangle_stat()
       end
 
     val op ## = OS.Path.concat infix ##
 
     local
-	  val region_profiling = Flags.lookup_flag_entry "region_profiling"
-	  val tag_values = Flags.is_on0 "tag_values"
-	  val tag_pairs_p = Flags.is_on0 "tag_pairs"
+          val region_profiling = Flags.lookup_flag_entry "region_profiling"
+          val tag_values = Flags.is_on0 "tag_values"
+          val tag_pairs_p = Flags.is_on0 "tag_pairs"
           val gc_p = Flags.is_on0 "garbage_collection"
           val gengc_p = Flags.is_on0 "generational_garbage_collection"
 
-	  fun path_to_runtime () =
+          fun path_to_runtime () =
             let fun file () =
               if parallelism_p() then
                 (if tag_values() then
@@ -325,19 +325,19 @@ structure ExecutionX64: EXECUTION =
                  else if argobots_p() then "runtimeSystemArPar.a"
                  else "runtimeSystemPar.a")
               else
-	      if !region_profiling andalso gc_p() andalso tag_pairs_p() then "runtimeSystemGCTPProf.a"  else
-	      if !region_profiling andalso gc_p() andalso gengc_p()     then "runtimeSystemGenGCProf.a" else
-	      if !region_profiling andalso gc_p()                       then "runtimeSystemGCProf.a"    else
-	      if !region_profiling                                      then "runtimeSystemProf.a"      else
+              if !region_profiling andalso gc_p() andalso tag_pairs_p() then "runtimeSystemGCTPProf.a"  else
+              if !region_profiling andalso gc_p() andalso gengc_p()     then "runtimeSystemGenGCProf.a" else
+              if !region_profiling andalso gc_p()                       then "runtimeSystemGCProf.a"    else
+              if !region_profiling                                      then "runtimeSystemProf.a"      else
               if                           gc_p() andalso tag_pairs_p() then "runtimeSystemGCTP.a"      else
               if                           gc_p() andalso gengc_p()     then "runtimeSystemGenGC.a"     else
               if                           gc_p()                       then "runtimeSystemGC.a"        else
               if tag_values()                     andalso tag_pairs_p() then
-		  die "no runtime system supports tagging of values with tagging of pairs"             else
+                  die "no runtime system supports tagging of values with tagging of pairs"             else
               if tag_values()                                           then "runtimeSystemTag.a"      else
-		                                                             "runtimeSystem.a"
-	    in !Flags.install_dir ## "lib" ## file()
-	    end
+                                                                             "runtimeSystem.a"
+            in !Flags.install_dir ## "lib" ## file()
+            end
     in
        val link_files_with_runtime_system = link_files_with_runtime_system0 path_to_runtime
     end
@@ -350,28 +350,26 @@ structure ExecutionX64: EXECUTION =
       val gc_p = Flags.is_on0 "garbage_collection"
       val gengc_p = Flags.is_on0 "generational_garbage_collection"
       val region_inference = Flags.is_on0 "region_inference"
-      val parallelism_p = Flags.is_on0 "parallelism"
-      val par_alloc_unprotected_p = Flags.is_on0 "parallelism_alloc_unprotected"
     in
       fun maybe_prefix_RI s =
           if region_inference() then "RI_" ^ s
           else s
 
-	(* Remember also to update RepositoryFinMap in Common/Elaboration.sml *)
-      fun mlbdir() =
-	  let val subdir =
-	      if recompile_basislib() then "Scratch"   (* avoid overwriting other files *)
-	      else
-		  case (gengc_p(),gc_p(), region_profiling(), tag_pairs_p()) of
-		      (false,     true,   true,               false) => maybe_prefix_RI "GC_PROF"
-		    | (false,     true,   false,              false) => maybe_prefix_RI "GC"
-		    | (false,     true,   true,               true)  => maybe_prefix_RI "GC_TP_PROF"
-		    | (false,     true,   false,              true)  => maybe_prefix_RI "GC_TP"
-		    | (true,      true,   true,               false) => maybe_prefix_RI "GENGC_PROF"
-		    | (true,      true,   false,              false) => maybe_prefix_RI "GENGC"
-		    | (true,      _,      _,                  _)     => die "Illegal combination of generational garbage collection and tagged pairs"
-		    | (false,     false,  true,               _)     => maybe_prefix_RI "PROF"
-		    | (false,     false,  false,              _)     => if region_inference() then "RI"
+        (* Remember also to update RepositoryFinMap in Common/Elaboration.sml *)
+      fun mlbdir () =
+          let val subdir =
+              if recompile_basislib() then "Scratch"   (* avoid overwriting other files *)
+              else
+                  case (gengc_p(),gc_p(), region_profiling(), tag_pairs_p()) of
+                      (false,     true,   true,               false) => maybe_prefix_RI "GC_PROF"
+                    | (false,     true,   false,              false) => maybe_prefix_RI "GC"
+                    | (false,     true,   true,               true)  => maybe_prefix_RI "GC_TP_PROF"
+                    | (false,     true,   false,              true)  => maybe_prefix_RI "GC_TP"
+                    | (true,      true,   true,               false) => maybe_prefix_RI "GENGC_PROF"
+                    | (true,      true,   false,              false) => maybe_prefix_RI "GENGC"
+                    | (true,      _,      _,                  _)     => die "Illegal combination of generational garbage collection and tagged pairs"
+                    | (false,     false,  true,               _)     => maybe_prefix_RI "PROF"
+                    | (false,     false,  false,              _)     => if region_inference() then "RI"
                                                                         else "NOGC"
               val subdir = if parallelism_p() then
                              if par_alloc_unprotected_p() then
@@ -382,15 +380,15 @@ structure ExecutionX64: EXECUTION =
                                "" => subdir
                              | x => if CharVector.all Char.isAlphaNum x then subdir ^ "_" ^ x
                                     else subdir
-	  in "MLB" ## subdir
-	  end
+          in "MLB" ## subdir
+          end
     end
 
     val pu_linkinfo =
-	let val pu_labels = Pickle.listGen Labels.pu
-	    val pu_pair = Pickle.pairGen(pu_labels,pu_labels)
-	in Pickle.convert (fn (c,i,e,u) => {code_label=c,imports=i,exports=e,unsafe=u},
-			   fn {code_label=c,imports=i,exports=e,unsafe=u} => (c,i,e,u))
-	    (Pickle.tup4Gen(Labels.pu,pu_pair,pu_pair,Pickle.bool))
-	end
+        let val pu_labels = Pickle.listGen Labels.pu
+            val pu_pair = Pickle.pairGen(pu_labels,pu_labels)
+        in Pickle.convert (fn (c,i,e,u) => {code_label=c,imports=i,exports=e,unsafe=u},
+                           fn {code_label=c,imports=i,exports=e,unsafe=u} => (c,i,e,u))
+            (Pickle.tup4Gen(Labels.pu,pu_pair,pu_pair,Pickle.bool))
+        end
   end

--- a/src/Compiler/Backend/X64/INSTS_X64.sml
+++ b/src/Compiler/Backend/X64/INSTS_X64.sml
@@ -134,6 +134,17 @@ signature INSTS_X64 =
     | jbe of lab        (* jump if below or equal---unsigned *)
     | jo of lab         (* jump on overflow *)
 
+    | cmovlq of ea * ea
+    | cmovgq of ea * ea
+    | cmovleq of ea * ea
+    | cmovgeq of ea * ea
+    | cmoveq of ea * ea
+    | cmovneq of ea * ea
+    | cmovaq of ea * ea
+    | cmovbq of ea * ea
+    | cmovaeq of ea * ea
+    | cmovbeq of ea * ea
+
     | call of lab       (* C function calls and returns *)
     | call' of ea       (* C function calls and returns *)
     | ret

--- a/src/Compiler/Backend/X64/InstsX64.sml
+++ b/src/Compiler/Backend/X64/InstsX64.sml
@@ -795,9 +795,15 @@ structure InstsX64: INSTS_X64 =
         let fun p (is,acc) =
                 case is of
                     nil => rev acc
+                  | (i as movq(R r1, R r2)) :: is =>
+                    if r1=r2 then p (is,acc) else p (is,i::acc)
                   | (i1 as movq(I "1",R r1)) :: (i2 as movq(I "1",R r2)) :: is =>
                     if r1 = r2 then p (i2 :: is,acc)
                     else p (i2 :: is, i1::acc)
+                  | (i1 as movq(R r1,ea1)) :: (i2 as movq(ea2,R r2)) :: is =>
+                    if ea1=ea2 andalso ea2 <> R r1 then
+                      p (movq(R r1,ea1) :: movq(R r1,R r2) :: is, acc)
+                    else p (i2::is,i1::acc)
                   | (i as jmp (L(LocalLab l1))) :: is =>
                     (case rem_dead_code is of
                          is as (lab (LocalLab l2) :: is') =>

--- a/src/Compiler/COMP_BASIS.sml
+++ b/src/Compiler/COMP_BASIS.sml
@@ -12,8 +12,9 @@ signature COMP_BASIS =
     type mulenv         (* for multiplicity inference *)
     type mularefmap     (* for multiplicity inference *)
     type rse            (* region static environment *)
-    type drop_env       (* lvar(fix) -> bool list *) 
+    type drop_env       (* lvar(fix) -> bool list *)
     type psi_env        (* lvar -> phsize list  minimal actual ph. sizes for FIX bound lvars *)
+    type protenv
 
     val empty : CompBasis
     val initial : CompBasis
@@ -21,18 +22,18 @@ signature COMP_BASIS =
     val eq : CompBasis * CompBasis -> bool
     val enrich : CompBasis * CompBasis -> bool
     val match : CompBasis * CompBasis -> CompBasis
-    val restrict : CompBasis * (lvar list * TyName list * con list * excon list) -> 
+    val restrict : CompBasis * (lvar list * TyName list * con list * excon list) ->
       CompBasis * lvar list * con list * excon list
 
       (* restrict0: Don't include identifiers that are declared by the initial basis *)
-    val restrict0 : CompBasis * (lvar list * TyName list * con list * excon list) -> 
+    val restrict0 : CompBasis * (lvar list * TyName list * con list * excon list) ->
       CompBasis * lvar list * con list * excon list
 
 
     val mk_CompBasis: {NEnv:NEnv,TCEnv:TCEnv,EqEnv:EqEnv,OEnv:OEnv,rse:rse,mulenv:mulenv,
-		       mularefmap:mularefmap,drop_env:drop_env,psi_env:psi_env} -> CompBasis
+		       mularefmap:mularefmap,drop_env:drop_env,psi_env:psi_env,protenv:protenv} -> CompBasis
     val de_CompBasis: CompBasis -> {NEnv:NEnv,TCEnv:TCEnv,EqEnv:EqEnv,OEnv:OEnv,rse:rse,mulenv:mulenv,
-				    mularefmap:mularefmap,drop_env:drop_env,psi_env:psi_env}
+				    mularefmap:mularefmap,drop_env:drop_env,psi_env:psi_env,protenv:protenv}
     type StringTree
     val layout_CompBasis: CompBasis -> StringTree
 

--- a/src/Compiler/CompBasis.sml
+++ b/src/Compiler/CompBasis.sml
@@ -23,6 +23,8 @@ structure CompBasis: COMP_BASIS =
     type mularefmap = Mul.mularefmap
     type drop_env = DropRegions.env
     type psi_env = PhysSizeInf.env
+    type protenv = MulExp.ProtInf.pe
+
     type CompBasis = {NEnv: NEnv,    (* type scheme normalize environment *)
                       TCEnv : TCEnv, (* lambda type check environment *)
                       EqEnv : EqEnv, (* elimination of polymorphic equality environment *)
@@ -31,7 +33,8 @@ structure CompBasis: COMP_BASIS =
                       mulenv: mulenv,
                       mularefmap: mularefmap,
                       drop_env: drop_env,
-                      psi_env: psi_env}
+                      psi_env: psi_env,
+                      protenv: protenv}
 
     fun mk_CompBasis a = a
     fun de_CompBasis a = a
@@ -44,7 +47,8 @@ structure CompBasis: COMP_BASIS =
                  mulenv=Mul.empty_efenv,
                  mularefmap=Mul.empty_mularefmap,
                  drop_env=DropRegions.empty,
-                 psi_env=PhysSizeInf.empty}
+                 psi_env=PhysSizeInf.empty,
+                 protenv=MulExp.ProtInf.empPE}
 
     val initial = {NEnv=Normalize.initial,
                    TCEnv=LambdaStatSem.initial,
@@ -54,11 +58,12 @@ structure CompBasis: COMP_BASIS =
                    mulenv=Mul.initial,
                    mularefmap=Mul.initial_mularefmap,
                    drop_env=DropRegions.init,
-                   psi_env=PhysSizeInf.init}
+                   psi_env=PhysSizeInf.init,
+                   protenv=MulExp.ProtInf.initPE}
 
-    fun plus ({NEnv,TCEnv,EqEnv,OEnv,rse,mulenv,mularefmap,drop_env,psi_env},
+    fun plus ({NEnv,TCEnv,EqEnv,OEnv,rse,mulenv,mularefmap,drop_env,psi_env,protenv},
               {NEnv=NEnv',TCEnv=TCEnv',EqEnv=EqEnv',OEnv=OEnv',rse=rse',mulenv=mulenv',
-               mularefmap=mularefmap',drop_env=drop_env',psi_env=psi_env'}) =
+               mularefmap=mularefmap',drop_env=drop_env',psi_env=psi_env',protenv=protenv'}) =
       {NEnv=Normalize.plus(NEnv,NEnv'),
        TCEnv=LambdaStatSem.plus(TCEnv,TCEnv'),
        EqEnv=EliminateEq.plus(EqEnv,EqEnv'),
@@ -67,10 +72,11 @@ structure CompBasis: COMP_BASIS =
        mulenv=Mul.plus(mulenv,mulenv'),
        mularefmap=Mul.plus_mularefmap(mularefmap, mularefmap'),
        drop_env=DropRegions.plus(drop_env, drop_env'),
-       psi_env=PhysSizeInf.plus(psi_env,psi_env')}
+       psi_env=PhysSizeInf.plus(psi_env,psi_env'),
+       protenv=MulExp.ProtInf.plus(protenv,protenv')}
 
     type StringTree = PP.StringTree
-    fun layout_CompBasis {NEnv,TCEnv,EqEnv,OEnv,rse,mulenv,mularefmap,drop_env,psi_env} =
+    fun layout_CompBasis {NEnv,TCEnv,EqEnv,OEnv,rse,mulenv,mularefmap,drop_env,psi_env,protenv} =
       PP.NODE{start="{", finish="}", indent=1, childsep=PP.RIGHT "; ",
               children=[Normalize.layout NEnv,
                         EliminateEq.layout_env EqEnv,
@@ -80,7 +86,8 @@ structure CompBasis: COMP_BASIS =
                         Mul.layout_efenv mulenv,
                         Mul.layout_mularefmap mularefmap,
                         DropRegions.layout_env drop_env,
-                        PhysSizeInf.layout_env psi_env
+                        PhysSizeInf.layout_env psi_env,
+                        MulExp.ProtInf.layoutPE protenv
                        ]
              }
 
@@ -110,10 +117,11 @@ structure CompBasis: COMP_BASIS =
       fun Mul_enrich_mularefmap a = Mul.enrich_mularefmap a
       fun DropRegions_enrich a = DropRegions.enrich a
       fun PhysSizeInf_enrich a = PhysSizeInf.enrich a
+      fun ProtEnv_enrich a = MulExp.ProtInf.enrich a
     in
-      fun enrich ({NEnv,TCEnv,EqEnv,OEnv,rse,mulenv,mularefmap,drop_env,psi_env},
+      fun enrich ({NEnv,TCEnv,EqEnv,OEnv,rse,mulenv,mularefmap,drop_env,psi_env,protenv},
                   {NEnv=NEnv1,TCEnv=TCEnv1,EqEnv=EqEnv1,OEnv=OEnv1,rse=rse1,mulenv=mulenv1,
-                   mularefmap=mularefmap1,drop_env=drop_env1,psi_env=psi_env1}) =
+                   mularefmap=mularefmap1,drop_env=drop_env1,psi_env=psi_env1,protenv=protenv1}) =
         debug("NEnv", NEnv_enrich(NEnv,NEnv1)) andalso
         debug("EqEnv", EliminateEq_enrich(EqEnv,EqEnv1)) andalso
         debug("TCEnv", LambdaStatSem_enrich(TCEnv,TCEnv1)) andalso
@@ -122,18 +130,19 @@ structure CompBasis: COMP_BASIS =
         debug("mulenv", Mul_enrich_efenv((mulenv,rse),(mulenv1,rse1))) andalso
         debug("mularefmap", Mul_enrich_mularefmap(mularefmap,mularefmap1)) andalso
         debug("drop_env", DropRegions_enrich(drop_env,drop_env1)) andalso
-        debug("psi_env", PhysSizeInf_enrich(psi_env,psi_env1))
+        debug("psi_env", PhysSizeInf_enrich(psi_env,psi_env1)) andalso
+        debug("protenv", ProtEnv_enrich(protenv,protenv1))
     end
 
-    fun match ({NEnv,TCEnv,EqEnv,OEnv,rse,mulenv,mularefmap,drop_env,psi_env},
+    fun match ({NEnv,TCEnv,EqEnv,OEnv,rse,mulenv,mularefmap,drop_env,psi_env,protenv},
                {NEnv=NEnv0,TCEnv=TCEnv0,EqEnv=EqEnv0,OEnv=OEnv0,rse=rse0,mulenv=mulenv0,
-                mularefmap=mularefmap0,drop_env=drop_env0,psi_env=psi_env0}) =
+                mularefmap=mularefmap0,drop_env=drop_env0,psi_env=psi_env0,protenv=protenv0}) =
       let val EqEnv = EliminateEq.match(EqEnv,EqEnv0)
       in {NEnv=NEnv,TCEnv=TCEnv,EqEnv=EqEnv,OEnv=OEnv,rse=rse,mulenv=mulenv,
-          mularefmap=mularefmap,drop_env=drop_env,psi_env=psi_env}
+          mularefmap=mularefmap,drop_env=drop_env,psi_env=psi_env,protenv=protenv}
       end
 
-    fun restrict ({NEnv,EqEnv,OEnv,TCEnv,rse,mulenv,mularefmap,drop_env,psi_env},
+    fun restrict ({NEnv,EqEnv,OEnv,TCEnv,rse,mulenv,mularefmap,drop_env,psi_env,protenv},
                   (lvars,tynames,cons,excons)) =
       let
 
@@ -184,6 +193,7 @@ structure CompBasis: COMP_BASIS =
           val mularefmap1 = Mul.restrict_mularefmap(mularefmap,effectvars)
           val drop_env1 = DropRegions.restrict(drop_env,lvars)
           val psi_env1 = PhysSizeInf.restrict(psi_env,lvars)
+          val protenv1 = MulExp.ProtInf.restrict(protenv,lvars)
       in ({NEnv=NEnv1,
            TCEnv=TCEnv1,
            EqEnv=EqEnv1,
@@ -192,7 +202,8 @@ structure CompBasis: COMP_BASIS =
            mulenv=mulenv1,
            mularefmap=mularefmap1,
            drop_env=drop_env1,
-           psi_env=psi_env1}, lvars, cons, excons)
+           psi_env=psi_env1,
+           protenv=protenv1}, lvars, cons, excons)
       end
 
     fun subtractPredefinedCons cons =
@@ -213,7 +224,7 @@ structure CompBasis: COMP_BASIS =
         TyName.Set.list
         (TyName.Set.difference (TyName.Set.fromList tns) (TyName.Set.fromList TyName.tynamesPredefined))
 
-    fun restrict0 ({NEnv,EqEnv,OEnv,TCEnv,rse,mulenv,mularefmap,drop_env,psi_env},
+    fun restrict0 ({NEnv,EqEnv,OEnv,TCEnv,rse,mulenv,mularefmap,drop_env,psi_env,protenv},
                   (lvars,tynames,cons,excons)) =
       let
           (* Don't include identifiers that are declared by the initial basis *)
@@ -236,6 +247,7 @@ structure CompBasis: COMP_BASIS =
           val mularefmap1 = Mul.restrict_mularefmap(mularefmap,nil)
           val drop_env1 = DropRegions.restrict(drop_env,lvars)
           val psi_env1 = PhysSizeInf.restrict(psi_env,lvars)
+          val protenv1 = MulExp.ProtInf.restrict(protenv,lvars)
       in ({NEnv=NEnv1,
            TCEnv=TCEnv1,
            EqEnv=EqEnv1,
@@ -244,20 +256,21 @@ structure CompBasis: COMP_BASIS =
            mulenv=mulenv1,
            mularefmap=mularefmap1,
            drop_env=drop_env1,
-           psi_env=psi_env1}, lvars, cons, excons)
+           psi_env=psi_env1,
+           protenv=protenv1}, lvars, cons, excons)
       end
 
     fun eq (B1,B2) = enrich(B1,B2) andalso enrich(B2,B1)
 
     val pu =
-        let fun to (((ne,tce),eqe,oe,rse),(me,mm,de,pe)) =
+        let fun to (((ne,tce),eqe,oe,rse),(me,mm,de,pe),protenv) =
             {NEnv=ne,TCEnv=tce, EqEnv=eqe, OEnv=oe, rse=rse,
-             mulenv=me, mularefmap=mm, drop_env=de, psi_env=pe}
+             mulenv=me, mularefmap=mm, drop_env=de, psi_env=pe,protenv=protenv}
             fun from {NEnv=ne,TCEnv=tce, EqEnv=eqe, OEnv=oe, rse,
-                      mulenv=me, mularefmap=mm, drop_env=de, psi_env=pe}
-                = (((ne,tce),eqe,oe,rse),(me,mm,de,pe))
+                      mulenv=me, mularefmap=mm, drop_env=de, psi_env=pe,protenv}
+                = (((ne,tce),eqe,oe,rse),(me,mm,de,pe),protenv)
         in Pickle.convert (to,from)
-            (Pickle.pairGen0(Pickle.tup4Gen0(Pickle.pairGen0(Pickle.comment "NEnv.pu" Normalize.pu,
+            (Pickle.tup3Gen0(Pickle.tup4Gen0(Pickle.pairGen0(Pickle.comment "NEnv.pu" Normalize.pu,
                                                              Pickle.comment "LambdaStatSem.pu" LambdaStatSem.pu),
                                              Pickle.comment "EliminateEq.pu" EliminateEq.pu,
                                              OptLambda.pu,
@@ -265,6 +278,7 @@ structure CompBasis: COMP_BASIS =
                              Pickle.tup4Gen0(Pickle.comment "Mul.efenv" Mul.pu_efenv,
                                              Pickle.comment "Mul.mularefmap" Mul.pu_mularefmap,
                                              Pickle.comment "DropRegions.env" DropRegions.pu_env,
-                                             Pickle.comment "PhysSizeInf.env" PhysSizeInf.pu_env)))
+                                             Pickle.comment "PhysSizeInf.env" PhysSizeInf.pu_env),
+                             MulExp.ProtInf.pu_pe))
         end
   end

--- a/src/Compiler/Regions/ADDRESS_LABELS.sml
+++ b/src/Compiler/Regions/ADDRESS_LABELS.sml
@@ -15,6 +15,7 @@ signature ADDRESS_LABELS =
     val eq        : label * label -> bool
     val lt        : label * label -> bool (* Used locally by ClosExp *)
     val key       : label -> int * string (* the string is the base (i.e., compilation unit) *)
+    val renew     : label -> string -> label
     val pr_label  : label -> string
 
     type name

--- a/src/Compiler/Regions/AddressLabels.sml
+++ b/src/Compiler/Regions/AddressLabels.sml
@@ -15,21 +15,25 @@ structure AddressLabels: ADDRESS_LABELS =
     fun new_named name = (Name.new (), name)
     fun key (n,s) = Name.key n
 
-    fun eq(l1,l2) = key l1 = key l2
-    fun lt(l1,l2) =
+    fun renew ((_,s1):label) (s2:string) = (Name.new(), s1 ^ "." ^ s2)
+
+    fun eq (l1,l2) = key l1 = key l2
+    fun lt (l1,l2) =
 	let val (i1,s1) = key l1
 	    val (i2,s2) = key l2
 	in i1 < i2 orelse (i1=i2 andalso s1 < s2)
 	end
 
-    fun pr_label(l,s) =
+    val xx = "abcdefghijklmnopqrstuvxyzABCDEFGHIJKLMNOPQRSTUVXYZ0123456789"
+    fun pr_label (l,s) =
 	let val (i,b) = Name.key l
-	in s ^ "$" ^ Int.toString i ^ "$" ^ b
+            val k = "$" ^ Int.toString i ^ "$" ^ b
+	in s ^ "_" ^ MD5.fromStringP xx k
 	end
 
     type name = Name.name
     fun name (l,s) = l
-    fun match((l1,_),(l2,_)) = Name.match(l1,l2)
+    fun match ((l1,_),(l2,_)) = Name.match(l1,l2)
 
     val reg_top_lab = (Name.reg_top, "reg_top")                   (* label 0 *)
     val reg_bot_lab = (Name.reg_bot, "reg_bot")                   (* label 1 *)

--- a/src/Compiler/Regions/EFFECT.sig
+++ b/src/Compiler/Regions/EFFECT.sig
@@ -37,6 +37,11 @@ sig
   val clearInstance: effect * effect -> unit
 
   val pix : effect -> int ref
+
+  val set_protect   : effect -> unit
+  val set_unprotect : effect -> unit
+  val get_protect   : effect -> bool option
+
   val remove_duplicates: effect list -> effect list
 
   val is_arrow_effect: effect -> bool

--- a/src/Compiler/Regions/MUL_EXP.sml
+++ b/src/Compiler/Regions/MUL_EXP.sml
@@ -226,4 +226,17 @@ signature MUL_EXP =
                           ('b -> StringTree option) ->
                           ('c -> StringTree option) -> ('a,'b,'c)trip -> StringTree
 
+    (* Protection inference *)
+    structure ProtInf : sig
+      type pe
+      val empPE    : pe
+      val initPE   : pe
+      val plus     : pe * pe -> pe
+      val enrich   : pe * pe -> bool
+      val restrict : pe * lvar list -> pe
+      val layoutPE : pe -> StringTree
+      val pu_pe    : pe Pickle.pu
+      val protInf  : pe -> (place,'a,'b)LambdaPgm -> pe
+    end
+
   end

--- a/src/Compiler/compiler_objects.mlb
+++ b/src/Compiler/compiler_objects.mlb
@@ -6,6 +6,7 @@ local
   basis SyntaxObjects = bas ../Common/syntax_objects.mlb end
   basis SpecialObjects = bas ../Common/special_objects.mlb end
   basis Basics = bas ../Common/basics.mlb end
+  basis Md5 = bas ../Common/md5.mlb end
   open BasLib
 in
   local open Tools Pickle
@@ -18,7 +19,7 @@ in
      in Lambda/Lvars.sml
         Lambda/Con.sml
         Lambda/Excon.sml
-        Regions/AddressLabels.sml
+        local open Md5 in Regions/AddressLabels.sml end
      end
   end
 

--- a/src/Compiler/regions.mlb
+++ b/src/Compiler/regions.mlb
@@ -18,7 +18,7 @@ in
   Regions/LOCALLY_LIVE_VARIABLES.sml
   local open Pickle in Regions/MUL.sig end
   local open SyntaxObjects in Regions/REGION_EXP.sml end
-  Regions/MUL_EXP.sml
+  local open Pickle in Regions/MUL_EXP.sml end
   Regions/MUL_INF.sml
   Regions/REGINF.sig
   local open Pickle SyntaxObjects in Regions/REGION_STAT_ENV.sml end
@@ -51,7 +51,7 @@ in
      local open Pickle in ../Common/QuasiEnv.sml end
      local open Edlib Pickle CompilerObjects in Regions/Mul.sml end
      local open CompilerObjects
-     in Regions/MulExp.sml
+     in local open Pickle in Regions/MulExp.sml end
         Regions/MulInf.sml
         Regions/LocallyLiveVariables.sml
         Regions/RegFlow.sml

--- a/src/Runtime/CommandLine.c
+++ b/src/Runtime/CommandLine.c
@@ -272,8 +272,12 @@ parseCmdLineArgs(int argc, char *argv[])
 	  fprintf(stderr,"Expecting integer argument to the option -P.\n");
 	  printUsage();
 	}
+	if (posixThreads < 1) {
+	  fprintf(stderr,"Expecting positive integer after option -P.\n");
+	  printUsage();
+	}
       } else {
-	fprintf(stderr,"No integer after the option -P.\n");
+	fprintf(stderr,"Expecting integer after the option -P.\n");
 	printUsage();
       }
       app_arg_index++; /* this is an two-word option */

--- a/src/Runtime/CommandLine.c
+++ b/src/Runtime/CommandLine.c
@@ -54,7 +54,7 @@ printUsage(void)
   fprintf(stderr,"      [-profTab] [-verbose] \n");
 #endif /*PROFILING*/
 #if (PARALLEL && ARGOBOTS)
-  fprintf(stderr,"      [-P n] [-verbose_par, -vp] \n");
+  fprintf(stderr,"      [-p n] [-verbose_par, -vp] \n");
 #endif
   fprintf(stderr,"  where\n");
   fprintf(stderr,"      -help, -h                Print this help screen and exit.\n\n");
@@ -69,7 +69,7 @@ printUsage(void)
   fprintf(stderr, "\n");
 #endif /*ENABLE_GC*/
 #ifdef ARGOBOTS
-  fprintf(stderr,"      -P n                     Number of execution streams.\n");
+  fprintf(stderr,"      -p n                     Number of execution streams.\n");
   fprintf(stderr,"      -verbose_par, -vp        Show info about parallel streams.\n\n");
 #endif
 #ifdef PROFILING
@@ -266,18 +266,18 @@ parseCmdLineArgs(int argc, char *argv[])
 #endif /*PROFILING*/
 
 #ifdef ARGOBOTS
-    if (strcmp((char *)argv[0],"-P")==0) {
+    if (strcmp((char *)argv[0],"-p")==0) {
       if (--argc > 0 && (*++argv)[0]) { /* Is there a number. */
 	if ((posixThreads = atoi((char *)argv[0])) == 0) {
-	  fprintf(stderr,"Expecting integer argument to the option -P.\n");
+	  fprintf(stderr,"Expecting integer argument to the option -p.\n");
 	  printUsage();
 	}
 	if (posixThreads < 1) {
-	  fprintf(stderr,"Expecting positive integer after option -P.\n");
+	  fprintf(stderr,"Expecting positive integer after option -p.\n");
 	  printUsage();
 	}
       } else {
-	fprintf(stderr,"Expecting integer after the option -P.\n");
+	fprintf(stderr,"Expecting integer after the option -p.\n");
 	printUsage();
       }
       app_arg_index++; /* this is an two-word option */

--- a/src/Runtime/GC.c
+++ b/src/Runtime/GC.c
@@ -350,7 +350,7 @@ mk_from_space_gen(Gen *gen)
     else
       gen->fp = NULL;
   }
-  gen->a = alloc_new_block(gen);
+  gen->a = alloc_new_page(gen);
 }
 
 static void mk_from_space(Context ctx)
@@ -1335,7 +1335,7 @@ gc(Context ctx, uintptr_t **sp, size_t reg_map)
   unsigned long alloc_period_save = 0;
   Ro *r;
 
-  // Mutex on the garbage collector; used by alloc_new_block in
+  // Mutex on the garbage collector; used by alloc_new_page in
   // Region.c for determining whether the tospace-bit should be set on
   // new allocated pages.
   doing_gc = 1;

--- a/src/Runtime/GC.c
+++ b/src/Runtime/GC.c
@@ -1315,7 +1315,7 @@ void
 gc(Context ctx, uintptr_t **sp, size_t reg_map)
 {
   long time_gc_one_ms = 0;
-  extern Rp* freelist;
+  extern Rp* global_freelist;
   uintptr_t **sp_ptr;
   uintptr_t *fd_ptr;
   unsigned long fd_size, fd_offset_to_return;
@@ -1634,8 +1634,8 @@ gc(Context ctx, uintptr_t **sp, size_t reg_map)
 #endif
 
   // We Are Done And Can Now Insert from-space Into The FreeList
-  from_space_end->n = freelist;
-  freelist = from_space_begin;
+  from_space_end->n = global_freelist;
+  global_freelist = from_space_begin;
 
   // If major GC run through all infinite regions and free all large
   // objects that have not been visited (are not marked as constant);

--- a/src/Runtime/Locks.h
+++ b/src/Runtime/Locks.h
@@ -2,30 +2,28 @@
 
 #define LOCKS_H
 
+#define FREELISTMUTEX      1
+#define FUNCTIONTABLEMUTEX 3
+
 #ifdef PARALLEL
+#include <pthread.h>
+
+typedef pthread_mutex_t thread_mutex_t;
+
+typedef struct thread_mutex_list {
+  thread_mutex_t mutex;
+  struct thread_mutex_list* next;
+} thread_mutex_list_t;
 
 void mutex_lock(int id);                      // defined in Spawn.c
 void mutex_unlock(int id);                    // defined in Spawn.c
 
 #define LOCK_LOCK(name) mutex_lock(name)
 #define LOCK_UNLOCK(name) mutex_unlock(name)
-#define FREELISTMUTEX      1
-#define FUNCTIONTABLEMUTEX 3
-
-#ifdef PARALLEL_GLOBAL_ALLOC_LOCK
-#define GLOBALALLOCMUTEX 4
-#endif // PARALLEL_GLOBAL_ALLOC_LOCK
-
-#define SHAREDFREELISTMUTEX 5
 
 #else // PARALLEL
 
 #include "../config.h"
-
-#define CODECACHEMUTEX     0
-#define FREELISTMUTEX      1
-#define STACKPOOLMUTEX     2
-#define FUNCTIONTABLEMUTEX 3
 
 #define LOCK_LOCK(name) ;
 #define LOCK_UNLOCK(name) ;

--- a/src/Runtime/Locks.h
+++ b/src/Runtime/Locks.h
@@ -16,6 +16,8 @@ void mutex_unlock(int id);                    // defined in Spawn.c
 #define GLOBALALLOCMUTEX 4
 #endif // PARALLEL_GLOBAL_ALLOC_LOCK
 
+#define SHAREDFREELISTMUTEX 5
+
 #else // PARALLEL
 
 #include "../config.h"

--- a/src/Runtime/Locks.h
+++ b/src/Runtime/Locks.h
@@ -3,8 +3,10 @@
 #define LOCKS_H
 
 #ifdef PARALLEL
+
 void mutex_lock(int id);                      // defined in Spawn.c
 void mutex_unlock(int id);                    // defined in Spawn.c
+
 #define LOCK_LOCK(name) mutex_lock(name)
 #define LOCK_UNLOCK(name) mutex_unlock(name)
 #define FREELISTMUTEX      1
@@ -18,9 +20,6 @@ void mutex_unlock(int id);                    // defined in Spawn.c
 
 #include "../config.h"
 
-#ifdef THREADS
-#ifdef PTHREADS
-
 #define CODECACHEMUTEX     0
 #define FREELISTMUTEX      1
 #define STACKPOOLMUTEX     2
@@ -28,18 +27,6 @@ void mutex_unlock(int id);                    // defined in Spawn.c
 
 #define LOCK_LOCK(name) ;
 #define LOCK_UNLOCK(name) ;
-#endif // PTHREADS
-
-#else // THREADS
-
-#define CODECACHEMUTEX     0
-#define FREELISTMUTEX      1
-#define STACKPOOLMUTEX     2
-#define FUNCTIONTABLEMUTEX 3
-
-#define LOCK_LOCK(name) ;
-#define LOCK_UNLOCK(name) ;
-#endif // THREADS
 
 #endif // PARALLEL
 

--- a/src/Runtime/Makefile.in
+++ b/src/Runtime/Makefile.in
@@ -6,6 +6,7 @@ CFLAGS=@CFLAGS@
 INSTALL=@INSTALL@
 INSTALLDATA=@INSTALL_DATA@
 INSTALLPROGRAM=@INSTALL_PROGRAM@
+ARGOBOTS_ROOT=@ARGOBOTS_ROOT@
 
 MKDIR=@top_srcdir@/mkinstalldirs
 
@@ -18,6 +19,7 @@ OFILESWITHGC=$(OFILES) GC.o
 OFILESWITHPAR=$(OFILES) Spawn.o
 CFILES_PAR=$(OFILESWITHPAR:%.o=%.c)
 OFILES_PAR=$(CFILES_PAR:%.c=%-par.o)
+OFILES_ARPAR=$(CFILES_PAR:%.c=%-arpar.o)
 CFILES = $(OFILESWITHGC:%.o=%.c)
 OFILES_PROF = $(OFILES:%.o=%-p.o)
 OFILES_TAG = $(OFILES:%.o=%-tag.o)
@@ -81,6 +83,9 @@ gen_syserror: gen_syserror.c
 %-par.o: %.c
 	$(CC) -c -DPARALLEL -DPARALLEL_GLOBAL_ALLOC_LOCK $(OPT) -o $*-par.o $<
 
+%-arpar.o: %.c
+	$(CC) -c -DARGOBOTS -DPARALLEL -DPARALLEL_GLOBAL_ALLOC_LOCK -I $(ARGOBOTS_ROOT)/src/include $(OPT) -o $@ $<
+
 runtimeSystem.a: $(OFILES) Makefile $(HEADER_FILES)
 	$(AR) $@ $(OFILES)
 	$(MKDIR) $(LIBDIR)
@@ -131,6 +136,11 @@ runtimeSystemPar.a: $(OFILES_PAR) Makefile $(HEADER_FILES)
 	$(MKDIR) $(LIBDIR)
 	$(INSTALLDATA) $@ $(LIBDIR)
 
+runtimeSystemArPar.a: $(OFILES_ARPAR) Makefile $(HEADER_FILES)
+	$(AR) $@ $(OFILES_ARPAR)
+	$(MKDIR) $(LIBDIR)
+	$(INSTALLDATA) $@ $(LIBDIR)
+
 depend:
 	mv Makefile.in Makefile.in.bak
 	(sed -n -e '1,/^### DO NOT DELETE THIS LINE/p' Makefile.in.bak;	 \
@@ -143,13 +153,14 @@ depend:
 	 $(CC) -MM -DTAG_VALUES -DENABLE_GC $(CFILES) | sed -e 's/\.o/-gc-tp.o/'; \
 	 $(CC) -MM -DTAG_VALUES -DPROFILING -DENABLE_GC $(CFILES) | sed -e 's/\.o/-gc-tp-p.o/'; \
 	 $(CC) -MM -DPARALLEL $(CFILES_PAR) | sed -e 's/\.o/-par.o/'; \
+	 $(CC) -MM -DARGOBOTS -DPARALLEL $(CFILES_PAR) -I $(ARGOBOTS_ROOT)/src/include | sed -e 's/\.o/-arpar.o/'; \
 	 $(CC) -MM -DTAG_VALUES -DTAG_FREE_PAIRS $(CFILES) | sed -e 's/\.o/-tag.o/') > Makefile.in
 	rm Makefile.in.bak
 
 clean:
 	rm -f $(OFILES) $(OFILES_TAG) $(OFILES_PROF) $(OFILES_GC) $(OFILES_GC_TP)
 	rm -f $(OFILES_GC_PROF) $(OFILES_GC_TP_PROF)
-	rm -f $(OFILES_GEN_GC_PROF) $(OFILES_GEN_GC) $(OFILES_PAR)
+	rm -f $(OFILES_GEN_GC_PROF) $(OFILES_GEN_GC) $(OFILES_PAR) $(OFILES_ARPAR)
 	rm -f core a.out *~ *.bak gen_syserror SysErrTable.h
 	rm -f runtimeSystemGCProf.a runtimeSystemGC.a
 	rm -f runtimeSystemGCTPProf.a runtimeSystemGCTP.a
@@ -183,6 +194,7 @@ hashmap_typed.o: ../CUtils/hashmap_typed.c ../CUtils/hashmap_typed.h \
 Export.o: Export.c String.h Flags.h Region.h Tagging.h \
   ../CUtils/polyhashmap.h ../CUtils/polyhashmap.c ../CUtils/hashfun.h \
   Export.h CommandLine.h
+Socket.o: Socket.c Region.h Flags.h List.h Tagging.h String.h Exception.h
 GC.o: GC.c
 Runtime-p.o: Runtime.c Runtime.h String.h Flags.h Region.h Tagging.h Math.h \
   Exception.h Table.h CommandLine.h Export.h Profiling.h
@@ -210,6 +222,7 @@ hashmap_typed-p.o: ../CUtils/hashmap_typed.c ../CUtils/hashmap_typed.h \
 Export-p.o: Export.c String.h Flags.h Region.h Tagging.h \
   ../CUtils/polyhashmap.h ../CUtils/polyhashmap.c ../CUtils/hashfun.h \
   Export.h CommandLine.h
+Socket-p.o: Socket.c Region.h Flags.h List.h Tagging.h String.h Exception.h
 GC-p.o: GC.c
 Runtime-gc.o: Runtime.c Runtime.h String.h Flags.h Region.h Tagging.h Math.h \
   Exception.h Table.h CommandLine.h Export.h GC.h
@@ -237,6 +250,7 @@ hashmap_typed-gc.o: ../CUtils/hashmap_typed.c ../CUtils/hashmap_typed.h \
 Export-gc.o: Export.c String.h Flags.h Region.h Tagging.h \
   ../CUtils/polyhashmap.h ../CUtils/polyhashmap.c ../CUtils/hashfun.h \
   Export.h CommandLine.h
+Socket-gc.o: Socket.c Region.h Flags.h List.h Tagging.h String.h Exception.h
 GC-gc.o: GC.c Flags.h Tagging.h Region.h String.h CommandLine.h Table.h \
   Exception.h Profiling.h Runtime.h GC.h
 Runtime-gengc.o: Runtime.c Runtime.h String.h Flags.h Region.h Tagging.h Math.h \
@@ -265,6 +279,7 @@ hashmap_typed-gengc.o: ../CUtils/hashmap_typed.c ../CUtils/hashmap_typed.h \
 Export-gengc.o: Export.c String.h Flags.h Region.h Tagging.h \
   ../CUtils/polyhashmap.h ../CUtils/polyhashmap.c ../CUtils/hashfun.h \
   Export.h CommandLine.h
+Socket-gengc.o: Socket.c Region.h Flags.h List.h Tagging.h String.h Exception.h
 GC-gengc.o: GC.c Flags.h Tagging.h Region.h String.h CommandLine.h Table.h \
   Exception.h Profiling.h Runtime.h GC.h
 Runtime-gc-p.o: Runtime.c Runtime.h String.h Flags.h Region.h Tagging.h Math.h \
@@ -293,6 +308,7 @@ hashmap_typed-gc-p.o: ../CUtils/hashmap_typed.c ../CUtils/hashmap_typed.h \
 Export-gc-p.o: Export.c String.h Flags.h Region.h Tagging.h \
   ../CUtils/polyhashmap.h ../CUtils/polyhashmap.c ../CUtils/hashfun.h \
   Export.h CommandLine.h
+Socket-gc-p.o: Socket.c Region.h Flags.h List.h Tagging.h String.h Exception.h
 GC-gc-p.o: GC.c Flags.h Tagging.h Region.h String.h CommandLine.h Table.h \
   Exception.h Profiling.h Runtime.h GC.h
 Runtime-gengc-p.o: Runtime.c Runtime.h String.h Flags.h Region.h Tagging.h Math.h \
@@ -321,6 +337,7 @@ hashmap_typed-gengc-p.o: ../CUtils/hashmap_typed.c ../CUtils/hashmap_typed.h \
 Export-gengc-p.o: Export.c String.h Flags.h Region.h Tagging.h \
   ../CUtils/polyhashmap.h ../CUtils/polyhashmap.c ../CUtils/hashfun.h \
   Export.h CommandLine.h
+Socket-gengc-p.o: Socket.c Region.h Flags.h List.h Tagging.h String.h Exception.h
 GC-gengc-p.o: GC.c Flags.h Tagging.h Region.h String.h CommandLine.h Table.h \
   Exception.h Profiling.h Runtime.h GC.h
 Runtime-gc-tp.o: Runtime.c Runtime.h String.h Flags.h Region.h Tagging.h Math.h \
@@ -349,6 +366,7 @@ hashmap_typed-gc-tp.o: ../CUtils/hashmap_typed.c ../CUtils/hashmap_typed.h \
 Export-gc-tp.o: Export.c String.h Flags.h Region.h Tagging.h \
   ../CUtils/polyhashmap.h ../CUtils/polyhashmap.c ../CUtils/hashfun.h \
   Export.h CommandLine.h
+Socket-gc-tp.o: Socket.c Region.h Flags.h List.h Tagging.h String.h Exception.h
 GC-gc-tp.o: GC.c Flags.h Tagging.h Region.h String.h CommandLine.h Table.h \
   Exception.h Profiling.h Runtime.h GC.h
 Runtime-gc-tp-p.o: Runtime.c Runtime.h String.h Flags.h Region.h Tagging.h Math.h \
@@ -377,16 +395,17 @@ hashmap_typed-gc-tp-p.o: ../CUtils/hashmap_typed.c ../CUtils/hashmap_typed.h \
 Export-gc-tp-p.o: Export.c String.h Flags.h Region.h Tagging.h \
   ../CUtils/polyhashmap.h ../CUtils/polyhashmap.c ../CUtils/hashfun.h \
   Export.h CommandLine.h
+Socket-gc-tp-p.o: Socket.c Region.h Flags.h List.h Tagging.h String.h Exception.h
 GC-gc-tp-p.o: GC.c Flags.h Tagging.h Region.h String.h CommandLine.h Table.h \
   Exception.h Profiling.h Runtime.h GC.h
 Runtime-par.o: Runtime.c Runtime.h String.h Flags.h Region.h Tagging.h Math.h \
-  Exception.h Table.h CommandLine.h Export.h
+  Exception.h Table.h CommandLine.h Export.h Spawn.h
 IO-par.o: IO.c IO.h Flags.h String.h Region.h Tagging.h Exception.h List.h \
   Math.h Runtime.h
 String-par.o: String.c String.h Flags.h Region.h Tagging.h List.h Exception.h
 Math-par.o: Math.c Math.h Flags.h Tagging.h Region.h String.h Exception.h
 Region-par.o: Region.c Flags.h Region.h Math.h Tagging.h String.h Profiling.h \
-  GC.h CommandLine.h Locks.h ../config.h Runtime.h
+  GC.h CommandLine.h Locks.h Spawn.h Runtime.h
 Icp-par.o: Icp.c
 Table-par.o: Table.c Table.h Region.h Flags.h Tagging.h
 Time-par.o: Time.c Tagging.h Flags.h Region.h String.h Math.h Exception.h
@@ -398,14 +417,36 @@ Posix-par.o: Posix.c Tagging.h Flags.h Region.h Exception.h String.h List.h \
   Posix.h SysErrTable.h
 Dlsym-par.o: Dlsym.c String.h Flags.h Region.h Tagging.h \
   ../CUtils/polyhashmap.h ../CUtils/polyhashmap.c ../CUtils/hashfun.h \
-  Locks.h ../config.h Dlsym.h
+  Locks.h Dlsym.h
 hashmap-par.o: ../CUtils/hashmap.c ../CUtils/hashmap.h
 hashmap_typed-par.o: ../CUtils/hashmap_typed.c ../CUtils/hashmap_typed.h \
   ../CUtils/hashmap.h
 Export-par.o: Export.c String.h Flags.h Region.h Tagging.h \
   ../CUtils/polyhashmap.h ../CUtils/polyhashmap.c ../CUtils/hashfun.h \
   Export.h CommandLine.h
-Spawn-par.o: Spawn.c Spawn.h Region.h Flags.h
+Socket-par.o: Socket.c Region.h Flags.h List.h Tagging.h String.h Exception.h
+Spawn-par.o: Spawn.c Spawn.h Region.h Flags.h Locks.h Tagging.h
+IO-arpar.o: IO.c IO.h Flags.h String.h Region.h Tagging.h Exception.h List.h \
+  Math.h Runtime.h
+String-arpar.o: String.c String.h Flags.h Region.h Tagging.h List.h Exception.h
+Math-arpar.o: Math.c Math.h Flags.h Tagging.h Region.h String.h Exception.h
+Icp-arpar.o: Icp.c
+Table-arpar.o: Table.c Table.h Region.h Flags.h Tagging.h
+Time-arpar.o: Time.c Tagging.h Flags.h Region.h String.h Math.h Exception.h
+Profiling-arpar.o: Profiling.c Profiling.h Region.h Flags.h Tagging.h String.h \
+  Exception.h
+Posix-arpar.o: Posix.c Tagging.h Flags.h Region.h Exception.h String.h List.h \
+  Posix.h SysErrTable.h
+Dlsym-arpar.o: Dlsym.c String.h Flags.h Region.h Tagging.h \
+  ../CUtils/polyhashmap.h ../CUtils/polyhashmap.c ../CUtils/hashfun.h \
+  Locks.h Dlsym.h
+hashmap-arpar.o: ../CUtils/hashmap.c ../CUtils/hashmap.h
+hashmap_typed-arpar.o: ../CUtils/hashmap_typed.c ../CUtils/hashmap_typed.h \
+  ../CUtils/hashmap.h
+Export-arpar.o: Export.c String.h Flags.h Region.h Tagging.h \
+  ../CUtils/polyhashmap.h ../CUtils/polyhashmap.c ../CUtils/hashfun.h \
+  Export.h CommandLine.h
+Socket-arpar.o: Socket.c Region.h Flags.h List.h Tagging.h String.h Exception.h
 Runtime-tag.o: Runtime.c Runtime.h String.h Flags.h Region.h Tagging.h Math.h \
   Exception.h Table.h CommandLine.h Export.h
 IO-tag.o: IO.c IO.h Flags.h String.h Region.h Tagging.h Exception.h List.h \
@@ -432,4 +473,5 @@ hashmap_typed-tag.o: ../CUtils/hashmap_typed.c ../CUtils/hashmap_typed.h \
 Export-tag.o: Export.c String.h Flags.h Region.h Tagging.h \
   ../CUtils/polyhashmap.h ../CUtils/polyhashmap.c ../CUtils/hashfun.h \
   Export.h CommandLine.h
+Socket-tag.o: Socket.c Region.h Flags.h List.h Tagging.h String.h Exception.h
 GC-tag.o: GC.c

--- a/src/Runtime/Makefile.in
+++ b/src/Runtime/Makefile.in
@@ -81,10 +81,10 @@ gen_syserror: gen_syserror.c
 	$(CC) -c -DTAG_VALUES -DPROFILING -DENABLE_GC $(OPT) -o $*-gc-tp-p.o $<
 
 %-par.o: %.c
-	$(CC) -c -DPARALLEL -DPARALLEL_GLOBAL_ALLOC_LOCK $(OPT) -o $*-par.o $<
+	$(CC) -c -DPARALLEL $(OPT) -o $*-par.o $<
 
 %-arpar.o: %.c
-	$(CC) -c -DARGOBOTS -DPARALLEL -DPARALLEL_GLOBAL_ALLOC_LOCK -I $(ARGOBOTS_ROOT)/src/include $(OPT) -o $@ $<
+	$(CC) -c -DARGOBOTS -DPARALLEL -I $(ARGOBOTS_ROOT)/src/include $(OPT) -o $@ $<
 
 runtimeSystem.a: $(OFILES) Makefile $(HEADER_FILES)
 	$(AR) $@ $(OFILES)

--- a/src/Runtime/Region.c
+++ b/src/Runtime/Region.c
@@ -514,9 +514,9 @@ alloc_new_page(Gen *gen)
  *----------------------------------------------------------------------*/
 
 static inline Region
-allocateRegion0(Context ctx, Region r)
+allocateRegion0(Context ctx, Region r, Protect protect)
 {
-  debug(printf("[allocateRegion0 (rAddr=%p)...",r));
+  debug(printf("[allocateRegion0 (rAddr=%p, protect=%ui)...",r,protect));
   r = clearStatusBits(r);
 
   CHECK_CTX("allocateRegion0");
@@ -527,7 +527,8 @@ allocateRegion0(Context ctx, Region r)
   r->g0.a = alloc_new_page(&(r->g0));      // Allocate the first region page in g0
 
 #ifdef PARALLEL
-  r->mutex = mutex_freelist_pop(ctx);
+  if ( protect ) { r->mutex = mutex_freelist_pop(ctx); }
+  else { r->mutex = NULL; }
 #endif
 
 #ifdef ENABLE_GEN_GC
@@ -543,18 +544,18 @@ allocateRegion0(Context ctx, Region r)
 }
 
 Region
-allocateRegion(Context ctx, Region r)
+allocateRegion(Context ctx, Region r, Protect p)
 {
-  r = allocateRegion0(ctx,r);
+  r = allocateRegion0(ctx,r,p);
   r = (Region)setInfiniteBit((uintptr_t)r);
   return r;
 }
 
 #ifdef ENABLE_GC
 Region
-allocatePairRegion(Context ctx, Region r)
+allocatePairRegion(Context ctx, Region r, Protect p)
 {
-  r = allocateRegion0(ctx,r);
+  r = allocateRegion0(ctx,r,p);
   set_pairregion(r->g0);
 #ifdef ENABLE_GEN_GC
   set_pairregion(r->g1);
@@ -564,9 +565,9 @@ allocatePairRegion(Context ctx, Region r)
 }
 
 Region
-allocateArrayRegion(Context ctx, Region r)
+allocateArrayRegion(Context ctx, Region r, Protect p)
 {
-  r = allocateRegion0(ctx,r);
+  r = allocateRegion0(ctx,r,p);
   set_arrayregion(r->g0);
 #ifdef ENABLE_GEN_GC
   set_arrayregion(r->g1);
@@ -576,9 +577,9 @@ allocateArrayRegion(Context ctx, Region r)
 }
 
 Region
-allocateRefRegion(Context ctx, Region r)
+allocateRefRegion(Context ctx, Region r, Protect p)
 {
-  r = allocateRegion0(ctx,r);
+  r = allocateRegion0(ctx,r,p);
   set_refregion(r->g0);
 #ifdef ENABLE_GEN_GC
   set_refregion(r->g1);
@@ -588,9 +589,9 @@ allocateRefRegion(Context ctx, Region r)
 }
 
 Region
-allocateTripleRegion(Context ctx, Region r)
+allocateTripleRegion(Context ctx, Region r, Protect p)
 {
-  r = allocateRegion0(ctx,r);
+  r = allocateRegion0(ctx,r,p);
   set_tripleregion(r->g0);
 #ifdef ENABLE_GEN_GC
   set_tripleregion(r->g1);

--- a/src/Runtime/Region.h
+++ b/src/Runtime/Region.h
@@ -427,10 +427,12 @@ extern Rp * global_freelist;
 #define CHECK_CTX(x) ;
 #endif
 
+typedef size_t Protect;
+
 /*----------------------------------------------------------------*
  *        Prototypes for external and internal functions.         *
  *----------------------------------------------------------------*/
-Region allocateRegion(Context ctx, Region roAddr);
+Region allocateRegion(Context ctx, Region roAddr, Protect p);
 void deallocateRegion(Context ctx);
 void deallocateRegionsUntil(Context ctx, Region rAddr);
 
@@ -450,10 +452,10 @@ void callSbrkArg(size_t no_of_region_pages);
 #endif
 
 #ifdef ENABLE_GC
-Region allocatePairRegion(Context ctx, Region roAddr);
-Region allocateArrayRegion(Context ctx, Region roAddr);
-Region allocateRefRegion(Context ctx, Region roAddr);
-Region allocateTripleRegion(Context ctx, Region roAddr);
+Region allocatePairRegion(Context ctx, Region roAddr, Protect p);
+Region allocateArrayRegion(Context ctx, Region roAddr, Protect p);
+Region allocateRefRegion(Context ctx, Region roAddr, Protect p);
+Region allocateTripleRegion(Context ctx, Region roAddr, Protect p);
 #ifdef PROFILING
 Region allocPairRegionInfiniteProfiling(Context ctx, Region r, size_t regionId);
 Region allocPairRegionInfiniteProfilingMaybeUnTag(Context ctx, Region r, size_t regionId);

--- a/src/Runtime/Region.h
+++ b/src/Runtime/Region.h
@@ -380,7 +380,6 @@ typedef struct {
   Region topregion;             // toplevel region
   void *exnptr;                 // pointer to toplevel handler
   long int uncaught_exnname;    // > 0 implies uncaught exception
-  Rp *freelist;
 } context;
 
 typedef context* Context;
@@ -393,7 +392,11 @@ extern Rp * freelist;
 
 #ifdef PARALLEL
 #define TOP_REGION   (thread_info()->top_region)
+#ifdef ARGOBOTS
+#define FREELIST     (freelists[execution_stream_rank()])
+#else
 #define FREELIST     (thread_info()->freelist)
+#endif
 #else
 #define TOP_REGION   ctx->topregion
 #define FREELIST     freelist
@@ -407,7 +410,7 @@ void deallocateRegion(Context ctx);
 void deallocateRegionsUntil(Context ctx, Region rAddr);
 
 uintptr_t *alloc (Region r, size_t n);
-uintptr_t *alloc_new_block(Gen *gen);
+uintptr_t *alloc_new_page(Gen *gen);
 void callSbrk();
 
 #ifdef PARALLEL_GLOBAL_ALLOC_LOCK

--- a/src/Runtime/Runtime.c
+++ b/src/Runtime/Runtime.c
@@ -104,6 +104,10 @@ terminateML (long status)
 #endif
   debug(printf("[terminateML..."));
 
+#ifdef PARALLEL
+  thread_finalize();
+#endif
+
 #ifdef PROFILING
   outputProfilePost();
   Statistics();

--- a/src/Runtime/Runtime.c
+++ b/src/Runtime/Runtime.c
@@ -370,10 +370,6 @@ extern void code(Context ctx);
 int
 main(int argc, char *argv[])
 {
-  Context ctx = (Context) malloc(sizeof(context));
-  ctx->topregion = NULL;
-  ctx->exnptr = NULL;
-
   //static struct sigaction sigact;
   //static sigset_t sigset;
 
@@ -386,7 +382,11 @@ main(int argc, char *argv[])
   parseCmdLineArgs(argc, argv);   /* also initializes ml-access to args */
 
 #ifdef PARALLEL
-  thread_init_all();
+  Context ctx = thread_init_all();
+#else
+  Context ctx = (Context) malloc(sizeof(context));
+  ctx->topregion = NULL;
+  ctx->exnptr = NULL;
 #endif
 
 #ifdef REGION_PAGE_STAT

--- a/src/Runtime/Spawn.c
+++ b/src/Runtime/Spawn.c
@@ -105,7 +105,7 @@ thread_init_all(void) {
   // Initialize Argobots
   ABT_init(0,NULL);
 
-  int is_randws = 0;
+  int is_randws = 1;
   // Create pools
   for (int i = 0; i < posixThreads; i++) {
     if (is_randws) {
@@ -203,11 +203,10 @@ thread_new(void* (*f)(ThreadInfo*), ThreadInfo* ti) {
   ABT_thread_attr_create(&attr);
   int stacksize = 1024 * 1024; // 1Mb
   ABT_thread_attr_set_stacksize(attr,stacksize);
-  // pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
   ti->fun = f;
   int rank;
   ABT_xstream_self_rank(&rank);
-  rc = ABT_thread_create_to(pools[rank], (void (*)(void*))callWrap, (void*)ti, attr, &(ti->thread));
+  rc = ABT_thread_create(pools[rank], (void (*)(void*))callWrap, (void*)ti, attr, &(ti->thread));
   if (rc) {
     printf("ERROR; return code from pthread_create() is %d (%s)\n", rc, strerror(rc));
     exit(-1);

--- a/test/parallelism/Makefile
+++ b/test/parallelism/Makefile
@@ -1,9 +1,16 @@
 FLAGS=-no_gc -par
-MLKIT=SML_LIB=../.. ../../bin/mlkit $(FLAGS)
+
+FLAGS_ARGO=-no_gc -par -argo -libs 'm,c,dl,abt' -libdirs '../../../argobots/src/.libs'
+
+MLKIT=SML_LIB=../.. ../../bin/mlkit
 
 .PHONY: all
 all:
-	../../bin/kittester "$(MLKIT)" --logdirect all.tst
+	../../bin/kittester "$(MLKIT) $(FLAGS)" --logdirect all.tst
+
+.PHONY: argo
+argo:
+	../../bin/kittester "$(MLKIT) $(FLAGS_ARGO)" --logdirect all.tst
 
 .PHONY: clean
 clean:

--- a/test/parallelism/spawn_lists.sml
+++ b/test/parallelism/spawn_lists.sml
@@ -22,7 +22,7 @@ structure T :> THREAD = struct
 end
 *)
 
-structure T :> THREAD = struct
+structure T (*:> THREAD*) = struct
 
   (* Note: By representing a thread by a pair of the thread function
      and the pointer to the C-managed data structure for the thread, we


### PR DESCRIPTION
This PR aims at using [Argobots](https://www.argobots.org/) for thread support in MLKit. Argobots can be configured with an execution stream per processor and a local pool (with work stealing) for each execution stream.  With this PR, MLKit can run with the following thread configurations:

1. Each MLKit thread corresponds to a posix thread (Pthread).
2. Each MLKit thread corresponds to an Argobot ultra-light thread (ULT). An ULT runs with its own stack.

### Compilation
To compile the MLKit with Argobots support, first copy the Argobots sources into a directory next to your MLKit sources:
```
$ cd ~/gits
$ git clone https://github.com/pmodels/argobots.git
```
Now, configure and build Argobots, as follows:
```
$ cd argobots
$ ./autogen.sh
$ ./configure
...
$ make
...
$ make install      // WARNING: You may not want to do this, in which case you need to 
                    // adjust the LD_LIBRARY_PATH for running the benchmarks later. Instead, maybe
                    // give a -prefix option to ./configure; see https://github.com/pmodels/argobots
```

You now need to configure and build the MLKit to use Argobots:
```
$ cd ~/gits/mlkit
$ git checkout argobots-integration
$ ./autobuild
$ ./configure --with-compiler=mlkit --with-argobots=~/gits/argobots
...
$ make mlkit && (cd src/Runtime; make runtimeSystemArPar.a) && make mlkit_basislibs
```

### Initial tests
Initial tests can be run as follows:
```
$ cd ~/gits/mlkit/test/parallelism
$ make clean && make all argo
```

### Benchmarks

To run benchmarks, first checkout the `mlkit-bench` repository into a directory next to your MLKit sources:

```
$ cd ~/gits
$ git clone https://github.com/melsman/mlkit-bench.git
```

Compile as follows:
```
$ cd mlkit-bench
$ make && (cd src/press; make)
```

To run the benchmarks, proceed as follows:
```
$ cd ~/gits/mlkit-bench/par-benchmarks
$ make clean report-arpar.json
```

To report the results, use the `mlkit-bench-press` tool:
```
$ make arpress
```

Here are the results on my Macbook pro 2016 (4(8) cores):
```
 | pname       | plen | real # argo | rss # argo | real # par | rss # par | real # seq | rss # seq |
 | fib         | 161  | 0.11 ±1%    | 26.8M ±0%  | 0.11 ±3%   | 2.7M ±0%  | 0.53 ±1%   | 2.1M ±0%  |
 | mandelbrot  | 355  | 0.25 ±4%    | 40.0M ±0%  | 0.20 ±1%   | 19.2M ±0% | 1.28 ±3%   | 8.4M ±0%  |
 | nqueens     | 243  | 0.79 ±3%    | 839M ±0%   | 0.77 ±2%   | 729M ±0%  | 1.84 ±4%   | 152M ±0%  |
 | pmsort      | 207  | 0.31 ±2%    | 245M ±0%   | 0.22 ±4%   | 226M ±0%  | 0.35 ±2%   | 81.9M ±0% |
 | primes      | 618  | 0.40 ±1%    | 85.9M ±0%  | 0.34 ±1%   | 53.7M ±0% | 1.23 ±1%   | 43.4M ±0% |
 | ray-orig    | 579  | 10.66 ±7%   | 1130M ±0%  | 5.14 ±0%   | 1208M ±0% | 11.33 ±2%  | 626M ±0%  |
 | ray         | 646  | 0.69 ±6%    | 218M ±0%   | 0.56 ±1%   | 183M ±0%  | 2.55 ±3%   | 28.3M ±0% |
 | seam-carve  | 1448 | 30.94 ±1%   | 5867M ±0%  | 26.64 ±1%  | 7781M ±0% | 11.97 ±6%  | 7367M ±0% |
 | filter      | 594  | 0.08 ±1%    | 356M ±0%   | 0.08 ±3%   | 326M ±0%  | 0.29 ±1%   | 325M ±0%  |
 | scan        | 595  | 0.14 ±0%    | 429M ±0%   | 0.14 ±1%   | 402M ±0%  | 0.54 ±2%   | 402M ±0%  |
 | sgm_scan    | 593  | 1.25 ±6%    | 822M ±0%   | 0.99 ±4%   | 799M ±0%  | 0.20 ±6%   | 322M ±0%  |
 | soboloption | 921  | 0.23 ±3%    | 34.7M ±0%  | 0.13 ±4%   | 13.0M ±0% | 0.45 ±2%   | 2.2M ±0%  |
 | sobolpi     | 893  | 0.21 ±2%    | 92.0M ±0%  | 0.18 ±1%   | 68.1M ±0% | 0.58 ±1%   | 18.1M ±0% |
 | vpmsort     | 226  | 0.14 ±2%    | 150M ±0%   | 0.10 ±2%   | 115M ±0%  | 0.30 ±2%   | 75.2M ±0% |
```

