### PR TITLE
fix problem with dangling pointers in exception values

### DIFF
--- a/src/Compiler/Regions/RType.sml
+++ b/src/Compiler/Regions/RType.sml
@@ -852,6 +852,54 @@ struct
       end handle MONOMORPHIC result => result
                | X => (print "regEffClos failed\n"; raise X)
 
+  (* New version below - mael 2022-11-23 *)
+  fun regEffClos0 (pr_lv, B: E.cone, B_0: int, phi: E.effect, tau: Type, ann: E.effect list) : E.cone * sigma =
+      let
+        val n = B_0
+        val B_1 = E.lower B_0 phi B
+        val annotations = ann_ty tau ann
+
+        (* if there are no potentially generalisable nodes, we can escape right away,
+           without going into the expensive operation of contracting effects *)
+        val _ = if List.exists (potentially_generalisable n) annotations then ()
+                else raise MONOMORPHIC(B_1,FORALL([],[],[],tau))
+
+        (* make sure there is at most one generalisable secondary effect variable *)
+        val B_2 = unify_generic_secondary_epss(B_1, n, E.subgraph annotations, annotations)
+
+        val subgraph = E.contract_effects annotations
+        (* nodes in "subgraph" are listed in bottom-up order, without
+           duplicates *)
+
+        val frv_tau = List.filter E.is_rho subgraph  (* no duplicates in frv_tau *)
+        val pfrv_tau = pfrv tau  (* syntactic order *)
+        val problematic_secondary_frv_tau =  (* no duplicates *)
+            List.filter (potentially_generalisable n)
+                        (E.setminus(frv_tau, pfrv_tau))
+
+        val (bound_secondary_rhos, B_3) =
+            unify_rho_partition(B_2,
+                                partition_rhos problematic_secondary_frv_tau)
+        val _ = set_pix_of_secondary_rhos bound_secondary_rhos
+
+        val primary_bound_rhos = E.remove_duplicates(List.filter (potentially_generalisable n) pfrv_tau)
+        val _ = set_pix_primary(primary_bound_rhos, pfrv_tau)
+        val bound_rhos = bound_secondary_rhos @ primary_bound_rhos
+
+        val fev_tau = List.filter E.is_arrow_effect subgraph (* bottom-up order, no duplicates *)
+        val pfev_tau = pfev tau @ ann     (* syntactic order *)
+        val problematic_secondary_fev_tau =  List.filter (potentially_generalisable n)
+                                                         (E.setminus(fev_tau,pfev_tau))
+        val _ = set_pix_of_secondary_epss problematic_secondary_fev_tau
+
+        val bound_epss = List.filter (potentially_generalisable n) fev_tau (* bottom-up order *)
+        val _ = set_pix_primary(E.setminus(bound_epss,problematic_secondary_fev_tau), pfev_tau)
+        val sigma = FORALL(bound_rhos, bound_epss, [], tau)
+      in
+        (B_3, sigma)
+      end handle MONOMORPHIC result => result
+               | X => (print "regEffClos failed\n"; raise X)
+
   fun regEffClos (B: E.cone, B_0: int, phi: E.effect, tau: Type) : E.cone * sigma =
       regEffClos0 (fn () => "uggh", B, B_0, phi, tau, nil)
 

--- a/src/Compiler/Regions/RType.sml
+++ b/src/Compiler/Regions/RType.sml
@@ -804,59 +804,6 @@ struct
       let
         val n = B_0
         val B_1 = E.lower B_0 phi B
-        val annotations = ann_ty tau []
-
-        (* if there are no potentially generalisable nodes, we can escape right away,
-           without going into the expensive operation of contracting effects *)
-        val _ = if List.exists (potentially_generalisable n) annotations then ()
-                else raise MONOMORPHIC(B_1,FORALL([],[],[],tau))
-
-        (* make sure there is at most one generalisable secondary effect variable *)
-        val B_2 = unify_generic_secondary_epss(B_1, n, E.subgraph annotations, annotations)
-
-        val subgraph = E.contract_effects annotations
-        (* nodes in "subgraph" are listed in bottom-up order, without
-           duplicates *)
-
-        val frv_tau = List.filter E.is_rho subgraph  (* no duplicates in frv_tau *)
-        val pfrv_tau = pfrv tau  (* syntactic order *)
-        val problematic_secondary_frv_tau =  (* no duplicates *)
-            List.filter (potentially_generalisable n)
-                        (E.setminus(frv_tau, pfrv_tau))
-
-        val (bound_secondary_rhos, B_3) =
-            unify_rho_partition(B_2,
-                                partition_rhos problematic_secondary_frv_tau)
-        val _ = set_pix_of_secondary_rhos bound_secondary_rhos
-
-        val primary_bound_rhos = E.remove_duplicates(List.filter (potentially_generalisable n) pfrv_tau)
-        val _ = set_pix_primary(primary_bound_rhos, pfrv_tau)
-        val bound_rhos = bound_secondary_rhos @ primary_bound_rhos
-
-        val fev_tau = List.filter E.is_arrow_effect subgraph (* bottom-up order, no duplicates *)
-        val pfev_tau = pfev tau      (* syntactic order *)
-        val problematic_secondary_fev_tau =  List.filter (potentially_generalisable n)
-                                                         (E.setminus(fev_tau,pfev_tau))
-        val _ = set_pix_of_secondary_epss problematic_secondary_fev_tau
-
-        (* deal with tv-annotated epss that have not yet been dealt with; give them pix-numbers according to
-         * how they appear in quantified type variable specs... *)
-        val epss_tvs = List.filter (potentially_generalisable n)
-                                   (E.setminus(E.remove_duplicates ann,fev_tau))
-
-        val bound_epss = List.filter (potentially_generalisable n) (fev_tau @ epss_tvs) (* bottom-up order *)
-        val _ = set_pix_primary(E.setminus(bound_epss,problematic_secondary_fev_tau), pfev_tau @ epss_tvs)
-        val sigma = FORALL(bound_rhos, bound_epss, [], tau)
-      in
-        (B_3, sigma)
-      end handle MONOMORPHIC result => result
-               | X => (print "regEffClos failed\n"; raise X)
-
-  (* New version below - mael 2022-11-23 *)
-  fun regEffClos0 (pr_lv, B: E.cone, B_0: int, phi: E.effect, tau: Type, ann: E.effect list) : E.cone * sigma =
-      let
-        val n = B_0
-        val B_1 = E.lower B_0 phi B
         val annotations = ann_ty tau ann
 
         (* if there are no potentially generalisable nodes, we can escape right away,

--- a/src/Compiler/Regions/SpreadExpression.sml
+++ b/src/Compiler/Regions/SpreadExpression.sml
@@ -362,15 +362,6 @@ struct
 
     val (freshType, freshMu) = R.freshType lookup
 
-(*
-    fun freshTypes (cone:cone, types: E.Type list) =
-        case types of
-            [] => ([],cone)
-          | (tau_ml::rest) => let val (tau, cone) = freshType(tau_ml,cone)
-                                  val (taus, cone) = freshTypes(cone,rest)
-                              in (tau::taus, cone)
-                              end
-*)
     fun freshTypesWithPlaces (cone:cone, types: E.Type list) =
         case types of
             [] => ([],cone)
@@ -875,8 +866,9 @@ good *)
            with type variables and have runtime type BOT become global.) *)
 
             (* If GC is enabled, we need to lower all region and
-               effect variables in mu to avoid dangling pointers in
-               exception values that escape to toplevel, for instance!
+               effect variables in the possible argument type to avoid
+               dangling pointers in exception values that perhaps
+               escape to toplevel!
              *)
 
             val B = Eff.lower 2 rho B

--- a/src/Compiler/Regions/SpreadExpression.sml
+++ b/src/Compiler/Regions/SpreadExpression.sml
@@ -91,9 +91,9 @@ struct
 
   infix footnote
   fun x footnote y = x
-  fun say(s) = TextIO.output(TextIO.stdOut, s ^ "\n");
-  fun logsay(s) = TextIO.output(!Flags.log, s);
-  fun logtree(t:PP.StringTree) = PP.outputTree(logsay, t, !Flags.colwidth)
+  fun say s = TextIO.output(TextIO.stdOut, s ^ "\n");
+  fun logsay s = TextIO.output(!Flags.log, s);
+  fun logtree (t:PP.StringTree) = PP.outputTree(logsay, t, !Flags.colwidth)
 
   fun log_sigma (sigma1, lvar) =
     case R.bv sigma1 of
@@ -225,11 +225,11 @@ struct
                  PP.flatten(PP.format(200, E.layoutLambdaExp e )) ^ "\n");
           raise Abort)
 
-  fun save_il(instances_opt, il_r) =
+  fun save_il (instances_opt, il_r) =
     (* record il in the environment ---
      to be picked up for letrec-bound variables at fix *)
-    (case instances_opt of
-       SOME(r as ref(list)) =>
+      case instances_opt of
+          SOME(r as ref(list)) =>
          (* lvar is fix bound or global
           (from earlier topdec);
           extend the instances list for
@@ -237,13 +237,12 @@ struct
           with the instantiation list of the lvar
          *)
          r:= il_r::list
-     | NONE => ()
-  );
+        | NONE => ()
 
-  fun pushIfNotTopLevel(toplevel,B) =
+  fun pushIfNotTopLevel (toplevel,B) =
       if toplevel then B else Eff.push B;
 
-  fun Below(B, mus) =
+  fun Below (B, mus) =
     let val free_rhos_and_epss = R.ann_mus mus []
         val B' = List.foldl (uncurry (Eff.lower(Eff.level B - 1)))
                             B free_rhos_and_epss
@@ -467,7 +466,8 @@ struct
         in (rho, R.mkBOX(tau,rho), B)
         end
 
-    fun maybe_explicit_rho_opt (rse:rse) (B:cone) (tau:R.Type) (rv_opt:RegVar.regvar option) : place option * R.mu * cone =
+    fun maybe_explicit_rho_opt (rse:rse) (B:cone) (tau:R.Type) (rv_opt:RegVar.regvar option)
+        : place option * R.mu * cone =
         let val (rho:place option,B) =
                 case rv_opt of
                     NONE =>
@@ -569,10 +569,12 @@ struct
                        end
 
     fun spreadSwitch' (B:cone) spread con excon_mus
-                 (E.SWITCH(e0: E.LambdaExp,
-                           choices: (('c * 'ignore) * E.LambdaExp) list,
-                           last: E.LambdaExp option),toplevel,cont) : cone * (place,unit)E'.trip * cont * tyvar list =
-      spreadSwitch B spread con excon_mus (E.SWITCH(e0, map (fn ((c,_),e) => (c,e)) choices, last),toplevel,cont)
+                      (E.SWITCH(e0: E.LambdaExp,
+                                choices: (('c * 'ignore) * E.LambdaExp) list,
+                                last: E.LambdaExp option),toplevel,cont)
+        : cone * (place,unit)E'.trip * cont * tyvar list =
+        spreadSwitch B spread con excon_mus (E.SWITCH(e0, map (fn ((c,_),e) => (c,e)) choices, last),
+                                             toplevel,cont)
 
     fun S (B,e,toplevel:bool,cont:cont) : cone * (place,unit)E'.trip * cont * tyvar list =
       (case e of
@@ -872,7 +874,14 @@ good *)
           (*NO! Lower only rho! (Otherwise region variables that are associated
            with type variables and have runtime type BOT become global.) *)
 
-            val B = Eff.lower 2 rho B
+            (* If GC is enabled, we need to lower all region and
+               effect variables in mu to avoid dangling pointers in
+               exception values that escape to toplevel, for instance!
+             *)
+
+            val B = if dangling_pointers()
+                    then Eff.lower 2 rho B
+                    else foldl (fn (e,B) => Eff.lower 2 e B) B (R.ann_mus [mu] [])
 
             (* if exception constructor is unary: unify place of exception
                constructor  and place of its result type. Note: I think
@@ -886,11 +895,14 @@ good *)
                       | _ => B
             val rse' = RSE.declareExcon(excon, mu, rse)
             val (B, t2 as E'.TR(e2', meta2, phi2), cont, tvs) = spreadExp(B,rse',e2, toplevel, cont)
+            val tvs' = if dangling_pointers()
+                       then nil
+                       else R.ftv_ty tau
         in
           retract(B, E'.TR(E'.EXCEPTION(excon, nullary, mu, rho, t2), meta2,
                            Eff.mkUnion([Eff.mkPut rho,phi2])),
                   cont,
-                  tvs)
+                  RSE.spuriousJoin tvs tvs')
         end
 
     | E.RAISE(e1: E.LambdaExp, description) =>

--- a/src/Runtime/GC.h
+++ b/src/Runtime/GC.h
@@ -7,7 +7,7 @@
 #ifndef GC_H
 #define GC_H
 
-#define CHECK_GC 1
+//#define CHECK_GC 1
 #ifdef ENABLE_GC
 extern size_t time_to_gc;
 extern size_t rp_gc_treshold;

--- a/src/Runtime/GC.h
+++ b/src/Runtime/GC.h
@@ -7,7 +7,7 @@
 #ifndef GC_H
 #define GC_H
 
-//#define CHECK_GC 1
+#define CHECK_GC 1
 #ifdef ENABLE_GC
 extern size_t time_to_gc;
 extern size_t rp_gc_treshold;

--- a/test/all.tst
+++ b/test/all.tst
@@ -69,6 +69,8 @@ oh-no2.sml          ccl       nobasislib
 real_match.sml                nobasislib
 gc0.sml                       nobasislib nooptimiser
 gc01.sml                      nobasislib nooptimiser
+exn.sml                       nobasislib nooptimiser
+exn-alpha.sml                 nobasislib nooptimiser
 
 (* Tests of some benchmark programs *)
 

--- a/test/exn-alpha.sml
+++ b/test/exn-alpha.sml
@@ -1,0 +1,44 @@
+infix  7  * / div mod
+infix  6  + - ^
+infixr 5  :: @
+infix  4  = <> > >= < <=
+infix  3  := o
+infix  0  before
+
+fun (s : string) ^ (s' : string) : string = prim ("concatStringML", (s, s'))
+
+fun nil @ ys     = ys
+  | (x::xs) @ ys = x :: (xs @ ys)
+
+fun print (s:string) : unit = prim("printStringML", s)
+
+fun f (x: 'a) : exn =
+    let exception E of 'a
+    in E x
+    end
+
+val e : exn =
+    let val y = "hi" ^ "there"
+    in f y
+    end
+
+fun length xs =
+    let fun acc [] k = k
+	  | acc (x::xr) k = acc xr (k+1)
+    in acc xs 0
+    end
+
+fun work n =
+    if n <= 3 then [n]
+    else
+    let val xs = work (n-1)
+        val ys = work (n-2)
+        val zs = work (n-3)
+        val zs = ((xs @ ys) @ zs) @ []
+        val n = length zs
+    in zs @ [n]
+    end
+
+val () = print "now working\n"
+val _ = work 20
+val () = print "done working\n"

--- a/test/exn-alpha.sml.out.ok
+++ b/test/exn-alpha.sml.out.ok
@@ -1,0 +1,2 @@
+now working
+done working

--- a/test/exn.sml
+++ b/test/exn.sml
@@ -1,0 +1,44 @@
+infix  7  * / div mod
+infix  6  + - ^
+infixr 5  :: @
+infix  4  = <> > >= < <=
+infix  3  := o
+infix  0  before
+
+fun (s : string) ^ (s' : string) : string = prim ("concatStringML", (s, s'))
+
+fun nil @ ys     = ys
+  | (x::xs) @ ys = x :: (xs @ ys)
+
+fun print (s:string) : unit = prim("printStringML", s)
+
+fun f (x: string) : exn = (* 'a *)
+    let exception E of string (* 'a *)
+    in E x
+    end
+
+val e : exn =
+    let val y = "hi" ^ "there"
+    in f y
+    end
+
+fun length xs =
+    let fun acc [] k = k
+	  | acc (x::xr) k = acc xr (k+1)
+    in acc xs 0
+    end
+
+fun work n =
+    if n <= 3 then [n]
+    else
+    let val xs = work (n-1)
+        val ys = work (n-2)
+        val zs = work (n-3)
+        val zs = ((xs @ ys) @ zs) @ []
+        val n = length zs
+    in zs @ [n]
+    end
+
+val () = print "now working\n"
+val _ = work 20
+val () = print "done working\n"

--- a/test/exn.sml.out.ok
+++ b/test/exn.sml.out.ok
@@ -1,0 +1,2 @@
+now working
+done working


### PR DESCRIPTION
To avoid dangling pointers in all possible exception values, we need to ensure that exception arguments are forced into global regions. When declaring local polymorphic exception constructors of the form `exception E of 'a`, we must make sure that all instantiations of `'a` are forced into global regions and effects. Luckily, we can apply the notion of _spurious type variables_, as introduced in #109, and enforce that type variables occurring in the type of exception constructors are considered spurious and that instantiated types are forced into global regions.  