### PR TITLE
Fix Posix.FileSys.fstat invalid file descriptor

### DIFF
--- a/src/Runtime/Posix.c
+++ b/src/Runtime/Posix.c
@@ -520,8 +520,9 @@ sml_stat(uintptr_t pair, String file)
 }
 
 uintptr_t
-sml_fstat(uintptr_t pair, size_t fd)
+sml_fstat(uintptr_t pair, long fd)
 {
+  fd = convertIntToC(fd);
   int res;
   struct stat b;
   mkTagPairML(pair);

--- a/src/Runtime/Posix.c
+++ b/src/Runtime/Posix.c
@@ -520,13 +520,12 @@ sml_stat(uintptr_t pair, String file)
 }
 
 uintptr_t
-sml_fstat(uintptr_t pair, long fd)
+sml_fstat(uintptr_t pair, size_t fd)
 {
-  fd = convertIntToC(fd);
   int res;
   struct stat b;
   mkTagPairML(pair);
-  res = fstat((int) fd, &b);
+  res = fstat(convertIntToC(fd), &b);
   if (res == -1)
   {
     elemRecordML(pair,0) = convertIntToML(-1);

--- a/test/posix.sml
+++ b/test/posix.sml
@@ -2,8 +2,8 @@
 fun check b = if b then "OK" else "WRONG";
 fun check' f = (if f () then "OK" else "WRONG") handle _ => "EXN";
 
-fun range (from, to) p = 
-    let open Int 
+fun range (from, to) p =
+    let open Int
     in
 	(from > to) orelse (p from) andalso (range (from+1, to) p)
     end;
@@ -14,28 +14,28 @@ fun tst0 s s' = print (s ^ "    \t" ^ s' ^ "\n");
 fun tst  s b = tst0 s (check  b);
 fun tst' s f = tst0 s (check' f);
 
-fun tstrange s bounds = (tst s) o range bounds  
+fun tstrange s bounds = (tst s) o range bounds
 
 
 val _ = print "\nFile posix.sml: Testing structure Posix...\n"
 val _ = print "\nFile posix.sml: Testing structure Posix.IO...\n"
 
 val channels = ref NONE
-val _ = tst' "Posix.IO.pipe" (fn () => let val {outfd,infd} = Posix.IO.pipe () 
+val _ = tst' "Posix.IO.pipe" (fn () => let val {outfd,infd} = Posix.IO.pipe ()
                                        in (channels := (SOME(infd,outfd)) ; true)
                                        end)
 
 val (infd,outfd) = Option.valOf (!channels)
 
-val child = (Posix.Process.fork () = NONE before tst0 "Posix.Process.fork" "OK") 
+val child = (Posix.Process.fork () = NONE before tst0 "Posix.Process.fork" "OK")
             handle _ => (tst0 "Posix.Process.fork" "EXN" before OS.Process.exit(OS.Process.failure);true)
 
-val _ = if child then 
+val _ = if child then
 	    let	val _ = tst' "Posix.IO.close" (fn () => (Posix.IO.close outfd; true))
 		val _ = Posix.Process.exit(0w0)
-	    in () 
+	    in ()
 	    end
-	else let val _ = tst' "Posix.IO.close" (fn () => (Posix.IO.close infd; true))			 
+	else let val _ = tst' "Posix.IO.close" (fn () => (Posix.IO.close infd; true))
 		 val _ = Posix.Process.wait()
 	     in ()
 	     end
@@ -51,3 +51,13 @@ val _ = tst' "Posix.uname" (fn () =>
 				      SOME s => s = "Linux" orelse s = "Darwin" orelse s = "FreeBSD"
 				    | NONE => false
 			       end)
+
+val _ = tst' "Posix.FileSys.fstat" (fn () =>
+  let
+    open Posix.FileSys
+    val file = openf ("posix.sml", O_RDONLY, O.fromWord 0w0)
+    val size1 = Position.toInt (ST.size (stat "posix.sml"))
+    val size2 = Position.toInt (ST.size (fstat file))
+  in
+    size1 = size2
+  end)

--- a/test/posix.sml.out.ok
+++ b/test/posix.sml.out.ok
@@ -8,3 +8,4 @@ Posix.IO.close    	OK
 Posix.Process.fork    	OK
 Posix.IO.close    	OK
 Posix.uname    	OK
+Posix.FileSys.fstat    	OK


### PR DESCRIPTION
Right now `Posix.FileSys.fstat` throws exceptions for invalid file descriptors because `file_desc` is being passed in without being converted to C.