### PR TITLE
REPL Proper Testing

### DIFF
--- a/basis/repl.sml
+++ b/basis/repl.sml
@@ -482,9 +482,8 @@ fun pretty_exported (i:int) : int =
                       | V s => ("tv: " ^ s, z_con1))
             in nopar (pr(depth,t,v))
             end handle _ => "_"
-        val s' : string = String.extract(str,0,SOME(Int.min(199,size str)))
-    in prim("pretty_ML_Print", (getCtx(),s',Match)) : unit
-     ; size s'
+    in prim("pretty_ML_Print", (getCtx(),str,Match)) : unit
+     ; size str
     end
 in
 val () = _export("pretty_exported", pretty_exported)


### PR DESCRIPTION
We need to set up proper automatic testing for the REPL, including testing of the various commands and with the basis library loaded...

Also, there are a number of ways in which the REPL can be caused to crash (or get into an unfortunate state), including (1) entering the expression `Posix.Process.fork()` at toplevel, (2) entering the expression `OS.FileSys.chDir ".."`, or (3) reloading an mlb-file after changing some of the source files it refers to. There seem to be no way (in general) to guard against the user doing stupid things like `(OS.Process.exit 0 : int)` or deleting the `MLB` directory that holds temporary files for the REPL. Item (2) above we can fix, however, and (3) we can support by resetting the interpreter (TERMINATE followed by a LOAD)... The effect, however, will be that all other declarations entered by the user will disappear...