### PR TITLE
FFI auto-conversion for chararray, i64, i32, and friends

### DIFF
--- a/src/Compiler/Backend/CALL_CONV.sml
+++ b/src/Compiler/Backend/CALL_CONV.sml
@@ -29,8 +29,8 @@ signature CALL_CONV =
                         {args: 'a list, rhos_for_result: 'a list, res: 'a list} * ('a*lvar) list * ('a*lvar) list
 
     val resolve_ccall_auto : lvar list -> lvar list -> (lvar -> 'a) ->
-                        {args: ('a*'b) list, res: ('a*'b)} ->
-                        {args: ('a*'b) list, res: ('a*'b)} * ('a*lvar) list * ('a*lvar) list
+                        {args: ('a*'b) list, rhos_for_result: 'a list, res: ('a*'b)} ->
+                        {args: ('a*'b) list, rhos_for_result: 'a list, res: ('a*'b)} * ('a*lvar) list * ('a*lvar) list
 
     val get_spilled_args              : cc -> lvar list
     val get_spilled_args_with_offsets : cc -> (lvar * offset) list

--- a/src/Compiler/Backend/CLOS_EXP.sml
+++ b/src/Compiler/Backend/CLOS_EXP.sml
@@ -42,7 +42,7 @@ signature CLOS_EXP =
     type cc
     type label
 
-    datatype foreign_type = CharArray | ForeignPtr | Bool | Int | Unit
+    datatype foreign_type = CharArray | ForeignPtr | Bool | Int | Int32 | Int64 | Unit
 
     datatype con_kind =  (* the integer is the index in the datatype 0,... *)
       ENUM of int
@@ -102,7 +102,8 @@ signature CLOS_EXP =
                           rhos_for_result : ClosExp list}
     | CCALL_AUTO      of {name: string,
                           args: (ClosExp * foreign_type) list,
-                          res: foreign_type}
+                          res: foreign_type,
+                          rhos_for_result : ClosExp list}   (* boxed res implies memory for the result *)
     | EXPORT          of {name: string,
                           clos_lab: label,
                           arg: ClosExp * foreign_type * foreign_type}

--- a/src/Compiler/Backend/CallConv.sml
+++ b/src/Compiler/Backend/CallConv.sml
@@ -256,10 +256,11 @@ functor CallConv(BI : BACKEND_INFO) : CALL_CONV =
           end
 
       fun resolve_ccall_auto args_phreg_ccall res_phreg_ccall (f: lvar  -> 'a)
-          {args: ('a*'b) list, res: 'a*'b} =
-          let val (args', alist_args, _) = resolve_list_auto f (args, nil, args_phreg_ccall)
+          {args: ('a*'b) list, rhos_for_result: 'a list, res: 'a*'b} =
+          let val (rhos_for_result',alist_args,phregs) = resolve_list f (rhos_for_result,[],args_phreg_ccall)
+              val (args', alist_args, _) = resolve_list_auto f (args, alist_args, phregs)
               val (res', alist_res, _) = resolve_auto f (res, nil, res_phreg_ccall)
-          in ({args=args',res=res'},
+          in ({args=args',rhos_for_result=rhos_for_result',res=res'},
               alist_args, alist_res)
           end
 

--- a/src/Compiler/Backend/FETCH_AND_FLUSH.sml
+++ b/src/Compiler/Backend/FETCH_AND_FLUSH.sml
@@ -3,11 +3,9 @@ signature FETCH_AND_FLUSH =
   sig
 
     (* Insert Fetch and Flush instructions in a LINE_STMT program
-       after register allocation.
+       after register allocation. *)
 
-    *)
-
-    type place 
+    type place
     type phsize
     type pp = int
     type lvar
@@ -26,18 +24,12 @@ signature FETCH_AND_FLUSH =
       | FLUSHED_CALLER_STY of lvar * lvar
       | FV_STY             of lvar * label * label
 
-    val IFF : {main_lab:label,code:(StoreTypeRA,unit,Atom) LinePrg,imports:label list * label list,exports:label list * label list} ->
-              {main_lab:label,code:(StoreType,unit,Atom) LinePrg,imports:label list * label list,exports:label list * label list}
+    val IFF : {main_lab:label,code:(StoreTypeRA,unit,Atom) LinePrg,
+               imports:label list * label list,exports:label list * label list} ->
+              {main_lab:label,code:(StoreType,unit,Atom) LinePrg,
+               imports:label list * label list,exports:label list * label list}
 
     val pr_sty    : StoreType -> string
     val pr_atom   : Atom -> string
 
   end
-
-
-
-
-
-
-
-

--- a/src/Compiler/Backend/FetchAndFlush.sml
+++ b/src/Compiler/Backend/FetchAndFlush.sml
@@ -14,7 +14,7 @@ functor FetchAndFlush(structure CallConv: CALL_CONV
                         where type label = AddressLabels.label
 			sharing type RegAlloc.Atom = LineStmt.Atom
 		      structure RI : REGISTER_INFO
-                        where type lvar = Lvars.lvar) 
+                        where type lvar = Lvars.lvar)
     : FETCH_AND_FLUSH =
 struct
   structure PP = PrettyPrint
@@ -53,7 +53,7 @@ struct
   fun msg s = TextIO.output(TextIO.stdOut, s)
   fun chat(s: string) = if !Flags.chat then print (s ^ "\n") else ()
   fun die s  = Crash.impossible ("FetchAndFlush." ^ s)
-  fun fast_pr stringtree = 
+  fun fast_pr stringtree =
     (PP.outputTree ((fn s => TextIO.output(!Flags.log, s)) , stringtree, !Flags.colwidth);
      TextIO.output(!Flags.log, "\n"))
 
@@ -85,9 +85,9 @@ struct
     (****************************************************************)
     (* Statistics                                                   *)
     (****************************************************************)
-    
+
     (* We record statistics for the entire program module.                     *)
-    local 
+    local
       val no_of_fetch    = ref 0
       val no_of_flush    = ref 0
     in
@@ -103,7 +103,7 @@ struct
     end
 
     (*****************************************)
-    (* Insert SCOPE on Callee Save Registers *)    
+    (* Insert SCOPE on Callee Save Registers *)
     (*****************************************)
     fun mk_flushed_callee([]) = []
       | mk_flushed_callee(phreg::phregs) = FLUSHED_CALLEE_STY phreg :: mk_flushed_callee phregs
@@ -127,10 +127,10 @@ struct
     (***************************************)
     fun F_sw(F_lss,LS.SWITCH(atom,sels,default),L_set,F_set,C_set) =
       let
-	val (L_set_sels, F_set_sels, C_set_sels) = 
-	  foldr (fn ((sel,lss), (L_set_acc, F_set, C_set)) => 
+	val (L_set_sels, F_set_sels, C_set_sels) =
+	  foldr (fn ((sel,lss), (L_set_acc, F_set, C_set)) =>
 		 let val (L_set', F_set', C_set') = F_lss(lss, L_set, F_set, C_set)
-		 in (Lvarset.union(L_set_acc, L_set'), F_set', C_set') 
+		 in (Lvarset.union(L_set_acc, L_set'), F_set', C_set')
 		 end) (Lvarset.empty, F_set, C_set) sels
 	val (L_set_def, F_set_def, C_set_def) = F_lss(default, L_set, F_set_sels, C_set_sels)
       in
@@ -150,7 +150,7 @@ struct
       end
 
     fun do_non_tail_ccall (ls,L_set,F_set,C_set) =
-      let 
+      let
 	val (def,use) = LS.def_use_lvar_ls ls
 	val lvars_to_flush = lvset_difference(L_set,def)
       in
@@ -164,19 +164,19 @@ struct
       in (Lvarset.lvarsetof use, F_set, C_set)
       end
 
-    fun F_ls(ls,L_set,F_set,C_set) = 
+    fun F_ls(ls,L_set,F_set,C_set) =
       (case ls of
 	 LS.FNCALL cc => do_non_tail_call(ls,L_set,F_set,C_set)
-       | LS.FNJMP cc => do_tail_call(ls,L_set,F_set,C_set) 
+       | LS.FNJMP cc => do_tail_call(ls,L_set,F_set,C_set)
        | LS.FUNCALL cc => do_non_tail_call(ls,L_set,F_set,C_set)
-       | LS.JMP cc => do_tail_call(ls,L_set,F_set,C_set) 
-       | LS.LETREGION{rhos,body} => 
-	   if only_null_rhos rhos 
+       | LS.JMP cc => do_tail_call(ls,L_set,F_set,C_set)
+       | LS.LETREGION{rhos,body} =>
+	   if only_null_rhos rhos
 	     orelse ( not(region_profiling()) andalso only_finite_rhos rhos ) then
 	     F_lss(body,L_set,F_set,C_set)
 	   else
 	     let
-	       (* A letregion calls a C function at entry (allocateRegion) 
+	       (* A letregion calls a C function at entry (allocateRegion)
 		* and at end (deallocateRegion), therefore the two unions below. *)
 	       val (L_set',F_set',C_set') = F_lss(body,L_set,F_set,Lvarset.union(C_set,L_set))
 	     in (* No variables are defined in a letregion construct. *)
@@ -185,16 +185,16 @@ struct
        | LS.SCOPE{pat,scope} => (* do also remove from C_set using RI.is_callee_save_c_call. 17/02/1999, Niels *)
 	   let
 	     val (L_set',F_set',C_set') = F_lss(scope,L_set,F_set,C_set)
-	     val lvs_to_remove_C = 
+	     val lvs_to_remove_C =
 	       let
 		 fun lv_to_remove_C(RA.STACK_STY lv,acc) = lv::acc
-		   | lv_to_remove_C(RA.PHREG_STY (lv,phreg),acc) = 
+		   | lv_to_remove_C(RA.PHREG_STY (lv,phreg),acc) =
 		   if RI.is_callee_save_ccall phreg then lv::acc
 		   else acc
 		   | lv_to_remove_C(RA.FV_STY lv,acc) = acc
 	       in foldr lv_to_remove_C [] pat
 	       end
-	     val lvs_to_remove_F = 
+	     val lvs_to_remove_F =
 	       let
 		 fun lv_to_remove_F(RA.STACK_STY lv,acc) = lv::acc
 		   | lv_to_remove_F(RA.PHREG_STY (lv,phreg),acc) = acc
@@ -209,13 +209,13 @@ struct
        | LS.HANDLE{default,handl=(handl,handl_lv),handl_return=([],handl_return_lv,bv),offset} =>
 	   let
 	     val (L_set1,F_set1,C_set1) = F_lss(default,L_set,F_set,C_set)
-	     val (L_set2,F_set2,C_set2) = F_lss(handl,L_set1,F_set1,C_set1) 
+	     val (L_set2,F_set2,C_set2) = F_lss(handl,L_set1,F_set1,C_set1)
 	     val handl_return_lvar = LS.get_var_atom (handl_return_lv,nil)
 	     val F_set3 = Lvarset.union(F_set2,lvset_difference(L_set,handl_return_lvar)) (* We must flush all caller save registers that are live *)
                                                                                           (* after the handle. We define handl_return_lv in the    *)
                                                                                           (* handle construct. 17/02/1999, Niels                   *)
 	   in
-	     (L_set2,F_set3,C_set2) 
+	     (L_set2,F_set3,C_set2)
 	   end
        | LS.HANDLE{default,handl,handl_return,offset} => die "F_ls: handl_return in HANDLE not empty"
        | LS.SWITCH_I {switch,precision} => F_sw(F_lss,switch,L_set,F_set,C_set)
@@ -223,8 +223,8 @@ struct
        | LS.SWITCH_S sw => F_sw(F_lss,sw,L_set,F_set,C_set)
        | LS.SWITCH_C sw => F_sw(F_lss,sw,L_set,F_set,C_set)
        | LS.SWITCH_E sw => F_sw(F_lss,sw,L_set,F_set,C_set)
-       | LS.CCALL{name,args,rhos_for_result,res} => do_non_tail_ccall(ls,L_set,F_set,C_set) 
-       | LS.CCALL_AUTO{name,args,res} => do_non_tail_ccall(ls,L_set,F_set,C_set) 
+       | LS.CCALL{name,args,rhos_for_result,res} => do_non_tail_ccall(ls,L_set,F_set,C_set)
+       | LS.CCALL_AUTO{name,args,rhos_for_result,res} => do_non_tail_ccall(ls,L_set,F_set,C_set)
        | _ =>
 	   let
 	     val (def,use) = LS.def_use_lvar_ls ls
@@ -233,8 +233,8 @@ struct
 	      F_set,
 	      C_set)
 	   end)
-    and F_lss(lss,L_set,F_set,C_set) = 
-      foldr 
+    and F_lss(lss,L_set,F_set,C_set) =
+      foldr
       (fn (ls,(L_set,F_set,C_set)) => F_ls(ls,L_set,F_set,C_set))
       (L_set,F_set,C_set) lss
 
@@ -242,7 +242,7 @@ struct
     (* Insert Flushes and Scope on Callee Save Registers *)
     (*****************************************************)
     fun assign_sty F (RA.STACK_STY lv) = STACK_STY lv
-      | assign_sty F (RA.PHREG_STY(lv,i)) = 
+      | assign_sty F (RA.PHREG_STY(lv,i)) =
       if Lvarset.member(lv,F) then
 	FLUSHED_CALLER_STY(lv,i)
       else
@@ -254,15 +254,15 @@ struct
 
     fun insert_flush([],C) = C
       | insert_flush((atom::atoms),C) = (inc_flush(); insert_flush (atoms,(LS.FLUSH(atom,())::C)))
-	 
+
     fun IFF_sw IFF_lss (LS.SWITCH(atom_arg,sels,default)) =
       LS.SWITCH(atom_arg,map (fn (s,lss) => (s,IFF_lss lss)) sels, IFF_lss default)
 
-    fun IFF_lss(lss,F,acc) = 
-      let 
+    fun IFF_lss(lss,F,acc) =
+      let
 	fun IFF_lss'([]) = acc
 	  | IFF_lss'(LS.ASSIGN{pat,bind}::lss) =
-	  if atom_in_F(pat,F) then 
+	  if atom_in_F(pat,F) then
 	    (inc_flush();
 	     LS.ASSIGN{pat=pat,bind=bind}::(LS.FLUSH(pat,()))::IFF_lss' lss)
 	  else
@@ -270,7 +270,7 @@ struct
 	  | IFF_lss'(LS.FLUSH _::lss) = die "IFF_ls: FLUSH not inserted yet!"
 	  | IFF_lss'(LS.FETCH _::lss) = die "IFF_ls: FETCH not inserted yet!"
 	  | IFF_lss'(LS.FNJMP cc::lss) = LS.FNJMP cc :: IFF_lss' lss
-	  | IFF_lss'(LS.FNCALL(cc as {res,...})::lss) = 
+	  | IFF_lss'(LS.FNCALL(cc as {res,...})::lss) =
 	    let
 	      val flushed_lvars = List.filter (fn atom => atom_in_F(atom,F)) res
 	    in
@@ -284,7 +284,7 @@ struct
 	      LS.FUNCALL cc :: (insert_flush(flushed_lvars,IFF_lss' lss))
 	    end
 	  | IFF_lss'(LS.LETREGION{rhos,body}::lss) = LS.LETREGION{rhos=rhos,body=IFF_lss(body,F,[])} :: IFF_lss' lss
-	  | IFF_lss'(LS.SCOPE{pat,scope}::lss) = LS.SCOPE{pat=map (assign_sty F) pat,scope=IFF_lss(scope,F,[])} :: IFF_lss' lss 
+	  | IFF_lss'(LS.SCOPE{pat,scope}::lss) = LS.SCOPE{pat=map (assign_sty F) pat,scope=IFF_lss(scope,F,[])} :: IFF_lss' lss
 	  | IFF_lss'(LS.HANDLE{default,handl=(handl,handl_lv),handl_return=([],handl_return_lv,bv),offset}::lss) =
 	    if atom_in_F(handl_return_lv,F) then (* handl_return_lv is defined and therefore flushed if necessary *)
 	      (inc_flush();
@@ -295,31 +295,31 @@ struct
 			handl_return=([],handl_return_lv,bv),offset=offset} :: IFF_lss' lss
 	  | IFF_lss'(LS.HANDLE{default,handl,handl_return,offset}::lss) = die "IFF_lss': handle_return in HANDLE not empty"
 	  | IFF_lss'(LS.RAISE{arg,defined_atys}::lss) = LS.RAISE{arg=arg,defined_atys=defined_atys} :: IFF_lss' lss
-	  | IFF_lss'(LS.SWITCH_I {switch,precision}::lss) = 
+	  | IFF_lss'(LS.SWITCH_I {switch,precision}::lss) =
 	      LS.SWITCH_I{switch=IFF_sw (fn lss => IFF_lss(lss,F,[])) switch,
 			  precision=precision} :: IFF_lss' lss
-	  | IFF_lss'(LS.SWITCH_W {switch,precision}::lss) = 
+	  | IFF_lss'(LS.SWITCH_W {switch,precision}::lss) =
 	      LS.SWITCH_W{switch=IFF_sw (fn lss => IFF_lss(lss,F,[])) switch,
 			  precision=precision} :: IFF_lss' lss
 	  | IFF_lss'(LS.SWITCH_S sw::lss) = LS.SWITCH_S(IFF_sw (fn lss => IFF_lss(lss,F,[])) sw) :: IFF_lss' lss
 	  | IFF_lss'(LS.SWITCH_C sw::lss) = LS.SWITCH_C(IFF_sw (fn lss => IFF_lss(lss,F,[])) sw) :: IFF_lss' lss
 	  | IFF_lss'(LS.SWITCH_E sw::lss) = LS.SWITCH_E(IFF_sw (fn lss => IFF_lss(lss,F,[])) sw) :: IFF_lss' lss
 	  | IFF_lss'(LS.RESET_REGIONS a::lss) = LS.RESET_REGIONS a :: IFF_lss' lss
-	  | IFF_lss'(LS.PRIM{name,args,res}::lss) = 
+	  | IFF_lss'(LS.PRIM{name,args,res}::lss) =
 	    let val flushed_lvars = List.filter (fn atom => atom_in_F(atom,F)) res
-	    in LS.PRIM{name=name,args=args,res=res} :: insert_flush(flushed_lvars,IFF_lss' lss) 
+	    in LS.PRIM{name=name,args=args,res=res} :: insert_flush(flushed_lvars,IFF_lss' lss)
 	    end
-	  | IFF_lss'(LS.CCALL{name,args,rhos_for_result,res}::lss) = 
+	  | IFF_lss'(LS.CCALL{name,args,rhos_for_result,res}::lss) =
 	    let val flushed_lvars = List.filter (fn atom => atom_in_F(atom,F)) res
 	    in LS.CCALL{name=name,args=args,rhos_for_result=rhos_for_result,res=res} :: insert_flush(flushed_lvars,IFF_lss' lss)
 	    end
-	  | IFF_lss'(LS.CCALL_AUTO{name,args,res}::lss) = 
-	    let val flushed_lvars = 
+	  | IFF_lss'(LS.CCALL_AUTO{name,args,rhos_for_result,res}::lss) =
+	    let val flushed_lvars =
 	          case res
 		    of (a,ft) => if atom_in_F(a,F) then [a] else nil
-	    in LS.CCALL_AUTO{name=name,args=args,res=res} :: insert_flush(flushed_lvars,IFF_lss' lss)
+	    in LS.CCALL_AUTO{name=name,args=args,rhos_for_result=rhos_for_result,res=res} :: insert_flush(flushed_lvars,IFF_lss' lss)
 	    end
-	  | IFF_lss'(LS.EXPORT{name,clos_lab,arg}::lss) = 
+	  | IFF_lss'(LS.EXPORT{name,clos_lab,arg}::lss) =
 	    LS.EXPORT{name=name,clos_lab=clos_lab,arg=arg} :: IFF_lss' lss
       in
 	IFF_lss' lss
@@ -328,7 +328,7 @@ struct
     (******************)
     (* Insert Fetches *)
     (******************)
-    fun IF_sw(IF_lss,switch_con,LS.SWITCH(atom,sels,default),U_set,lss) = 
+    fun IF_sw(IF_lss,switch_con,LS.SWITCH(atom,sels,default),U_set,lss) =
       let
 	val (acc,U_set_acc) = IF_lss(lss,U_set)
 	val (sels',U_set_sels) =
@@ -362,16 +362,16 @@ struct
 	fun IF_lss'([],U_set) = ([],U_set)
 	  | IF_lss'((ls as LS.FNCALL cc)::lss,U_set) = do_non_tail_call_if(ls,F_set,IF_lss'(lss,U_set))
 	  | IF_lss'((ls as LS.FUNCALL cc)::lss,U_set) = do_non_tail_call_if(ls,F_set,IF_lss'(lss,U_set))
-	  | IF_lss'(LS.LETREGION{rhos,body}::lss,U_set) =  
+	  | IF_lss'(LS.LETREGION{rhos,body}::lss,U_set) =
 	  (* If we have any infinite regions, then we perform a C-call at entry (allocRegion) and at
 	   * exit (deallocateRegion). We must then fetch caller save registers! When profiling is enabled,
 	   * we perform C calls at entry and exit also for finite regions. *)
 	  let
 	    val (acc,U_set_acc) = IF_lss'(lss,U_set)
 	    val ccalls_in_and_out : bool =
-	      only_null_rhos rhos orelse ( not(region_profiling()) 
+	      only_null_rhos rhos orelse ( not(region_profiling())
 					  andalso only_finite_rhos rhos )
-	    val lv_fetch2 = 
+	    val lv_fetch2 =
 	      if ccalls_in_and_out then	Lvarset.empty
 	      else Lvarset.intersection(C_set,U_set_acc)
 
@@ -408,18 +408,18 @@ struct
 				       offset=offset}::acc,U_set2)
 	    | _ => die "IF_lss': handl_return contains more than one statement."
 	  end
-	  | IF_lss'(LS.SWITCH_I {switch,precision}::lss,U_set) = 
+	  | IF_lss'(LS.SWITCH_I {switch,precision}::lss,U_set) =
 	  IF_sw(IF_lss',fn sw => LS.SWITCH_I {switch=sw, precision=precision},
 		switch,U_set,lss)
-	  | IF_lss'(LS.SWITCH_W {switch,precision}::lss,U_set) = 
+	  | IF_lss'(LS.SWITCH_W {switch,precision}::lss,U_set) =
 	  IF_sw(IF_lss',fn sw => LS.SWITCH_W {switch=sw, precision=precision},
 		switch,U_set,lss)
 	  | IF_lss'(LS.SWITCH_S sw::lss,U_set) = IF_sw(IF_lss',LS.SWITCH_S,sw,U_set,lss)
 	  | IF_lss'(LS.SWITCH_C sw::lss,U_set) = IF_sw(IF_lss',LS.SWITCH_C,sw,U_set,lss)
 	  | IF_lss'(LS.SWITCH_E sw::lss,U_set) = IF_sw(IF_lss',LS.SWITCH_E,sw,U_set,lss)
-	  | IF_lss'((ls as LS.CCALL{name,args,rhos_for_result,res})::lss,U_set) = 
+	  | IF_lss'((ls as LS.CCALL{name,args,rhos_for_result,res})::lss,U_set) =
 	  do_non_tail_call_if(ls,C_set,IF_lss'(lss,U_set)) (* Note, we use C_set and not F_set *)
-	  | IF_lss'((ls as LS.CCALL_AUTO{name,args,res})::lss,U_set) = 
+	  | IF_lss'((ls as LS.CCALL_AUTO{name,args,rhos_for_result,res})::lss,U_set) =
 	  do_non_tail_call_if(ls,C_set,IF_lss'(lss,U_set)) (* Note, we use C_set and not F_set *)
 	  | IF_lss'(ls::lss,U_set) =
 	  let
@@ -462,9 +462,9 @@ struct
 	val _ = chat "[Insert Fetch and Flush..."
 	val _ = reset_stat()
 	val line_prg_iff = foldr (fn (func,acc) => IFF_top_decl func :: acc) [] ra_prg
-	val _ = 
+	val _ =
 	  if print_fetch_and_flush_program() then
-	    display("\nReport: AFTER INSERT FETCH AND FLUSH:", 
+	    display("\nReport: AFTER INSERT FETCH AND FLUSH:",
 		    LS.layout_line_prg pr_sty (fn _ => "()") pr_atom false line_prg_iff)
 	  else ()
 (*	val _ = pp_stat() *)

--- a/src/Compiler/Backend/LINE_STMT.sml
+++ b/src/Compiler/Backend/LINE_STMT.sml
@@ -29,11 +29,11 @@ signature LINE_STMT =
     type label
     type ClosPrg
 
-    (* for use with the CCALL_AUTO construct: *)
+    (* for use with the CCALL_AUTO construct: (see also CLOS_EXP) *)
     datatype foreign_type =
       CharArray               (* When passed to a c-function, the
 			       * data field of the ML char-array is
-			       * passed. Char-arrays in the Kit are
+			       * passed. Char-arrays in MLKit are
 			       * zero-terminated and prefixed
                                * with a size-tag. CharArray may
 			       * not appear in a function result
@@ -48,6 +48,12 @@ signature LINE_STMT =
     | Int                     (* Integers (and words) are tagged
 			       * when garbage collection is
 			       * enabled. *)
+    | Int32                   (* Int32 (and word32) values are
+                               * boxed when garbage collection is
+                               * enabled. *)
+    | Int64                   (* Int64 (and word64) values are
+                               * boxed when garbage collection is
+                               * enabled. *)
     | Unit                    (* Possible in results *)
 
     datatype con_kind =  (* the integer is the index in the datatype 0,... *)
@@ -125,7 +131,8 @@ signature LINE_STMT =
     | CCALL         of {name: string, args: 'aty list,
 			rhos_for_result : 'aty list, res: 'aty list}
     | CCALL_AUTO    of {name: string, args: ('aty * foreign_type) list,
-			res: 'aty * foreign_type}
+			rhos_for_result : 'aty list,
+                        res: 'aty * foreign_type}
     | EXPORT        of {name: string, clos_lab: label, arg: 'aty * foreign_type * foreign_type}
 
     and ('a,'sty,'offset,'aty) Switch = SWITCH of 'aty * ('a * (('sty,'offset,'aty) LineStmt list)) list * (('sty,'offset,'aty) LineStmt list)

--- a/src/Compiler/Backend/RegAlloc.sml
+++ b/src/Compiler/Backend/RegAlloc.sml
@@ -152,19 +152,21 @@ struct
       | CC_ls(LS.CCALL{name,args,rhos_for_result,res},rest) =
         let
           val ({args,rhos_for_result,res},assign_list_args,assign_list_res) =
-              CallConv.resolve_ccall RI.args_phreg_ccall RI.res_phreg_ccall LS.PHREG {args=args,rhos_for_result=rhos_for_result,res=res}
+              CallConv.resolve_ccall RI.args_phreg_ccall RI.res_phreg_ccall LS.PHREG
+                                     {args=args,rhos_for_result=rhos_for_result,res=res}
         in
           resolve_res(assign_list_args,
                       LS.CCALL{name=name,args=args,rhos_for_result=rhos_for_result,res=res}::
                       resolve_args(assign_list_res,rest))
         end
-      | CC_ls(LS.CCALL_AUTO{name,args,res},rest) =
+      | CC_ls(LS.CCALL_AUTO{name,args,rhos_for_result,res},rest) =
         let
-          val ({args,res},assign_list_args,assign_list_res) =
-            CallConv.resolve_ccall_auto RI.args_phreg_ccall RI.res_phreg_ccall LS.PHREG {args=args,res=res}
+          val ({args,rhos_for_result,res},assign_list_args,assign_list_res) =
+              CallConv.resolve_ccall_auto RI.args_phreg_ccall RI.res_phreg_ccall LS.PHREG
+                                          {args=args,rhos_for_result=rhos_for_result,res=res}
         in
           resolve_res(assign_list_args,
-                      LS.CCALL_AUTO{name=name,args=args,res=res}::
+                      LS.CCALL_AUTO{name=name,args=args,rhos_for_result=rhos_for_result,res=res}::
                       resolve_args(assign_list_res,rest))
         end
       | CC_ls (ls,rest) = ls::rest

--- a/src/Compiler/Backend/SubstAndSimplify.sml
+++ b/src/Compiler/Backend/SubstAndSimplify.sml
@@ -277,8 +277,9 @@ struct
             LS.PRIM{name=name,args=atoms_to_atys args,res=atoms_to_atys res} :: SS_lss(lss,ATYmap,RHOmap)
           | SS_lss'(LS.CCALL{name,args,rhos_for_result,res}::lss) =
             LS.CCALL{name=name,args=atoms_to_atys args,rhos_for_result=atoms_to_atys rhos_for_result,res=atoms_to_atys res} :: SS_lss(lss,ATYmap,RHOmap)
-          | SS_lss'(LS.CCALL_AUTO{name,args,res}::lss) =
+          | SS_lss'(LS.CCALL_AUTO{name,args,rhos_for_result,res}::lss) =
             LS.CCALL_AUTO{name=name,args=map (fn (a,ft) => (atom_to_aty' a,ft)) args,
+                          rhos_for_result=atoms_to_atys rhos_for_result,
                           res=case res of (a,ft) => (atom_to_aty' a,ft)} ::
             SS_lss(lss,ATYmap,RHOmap)
           | SS_lss'(LS.EXPORT{name,clos_lab,arg=(a,ft1,ft2)}::lss) =

--- a/src/Compiler/Backend/X64/CodeGenX64.sml
+++ b/src/Compiler/Backend/X64/CodeGenX64.sml
@@ -1398,14 +1398,14 @@ struct
                                 end handle X => ( print ("EXN: CCALL: " ^ pr_ls ls ^ "\n")
                                                 ; raise X))
                   end
-               | LS.CCALL_AUTO{name, args, res} =>
+               | LS.CCALL_AUTO{name, args, rhos_for_result, res} =>
 
         (* With dynamicly linked functions the first argument must be the name of   *)
         (* the function. If we where to implement automatic conversion into regions *)
         (* this must be taken care of, like in the non-automatic case               *)
 
                     comment_fn (fn () => "CCALL_AUTO: " ^ pr_ls ls,
-                                compile_c_call_auto(name,args,res,size_ff,tmp_reg1,C)
+                                compile_c_call_auto(name,args,rhos_for_result,res,size_ff,tmp_reg1,C)
                                 handle X => ( print ("EXN: CCALL_AUTO: " ^ pr_ls ls ^ "\n")
                                             ; raise X)
                                )

--- a/src/Runtime/Math.c
+++ b/src/Runtime/Math.c
@@ -931,15 +931,14 @@ sml_bytes_to_real(size_t d, String s)
   return d;
 }
 
-
 /* A test function for testing auto */
 uintptr_t
 runtime_test0 (uintptr_t a1, uintptr_t a2, uintptr_t a3) {
   long int ret =
-    2 * (long int)a1 +
+    1 * (long int)a1 +
     3 * (long int)a2 +
     5 * (long int)a3;
-  return ret;              /* (2*1)+(3*2)+(5*3) ==> 23 */
+  return ret;              /* (1*1)+(3*2)+(5*3) ==> 22 */
 }
 
 /* A test function for testing multi-parameter passing (non-auto) */

--- a/src/Runtime/String.c
+++ b/src/Runtime/String.c
@@ -405,3 +405,8 @@ printLong(ssize_t n)
   printf("Long signed: %ld\n", convertIntToC((long int)n));
   return;
 }
+
+void
+runtime_test_cstring0(char *a, uintptr_t idx, char c) {
+  a[idx] = c;
+}

--- a/test_dev/auto.out.ok
+++ b/test_dev/auto.out.ok
@@ -1,1 +1,11 @@
-Num: 23
+Num: 42
+Num: 42
+ok: i64
+Num: 42
+ok: i32
+ok: i64
+ok: i64(2)
+ok: i32 res
+ok: i32 res2
+hello
+ok: chararray

--- a/test_dev/auto.sml
+++ b/test_dev/auto.sml
@@ -1,10 +1,103 @@
+local
+infix  7  * / div mod
+infix  6  + - ^
+infixr 5  :: @
+infix  4  = <> > >= < <=
+infix  3  := o
+infix  0  before
 
-fun runtime_test0 (a1:int,a2:int,a3:int) : int =
-    prim("@runtime_test0", (a1,a2,a3))
-
+fun !(x: 'a ref): 'a = prim ("!", x)
+fun (x: 'a ref) := (y: 'a): unit = prim (":=", (x, y))
+fun op = (x: ''a, y: ''a): bool = prim ("=", (x, y))
+fun not true = false | not false = true
+fun a <> b = not (a = b)
 fun print (s:string) : unit = prim("printStringML", s)
 fun printNum (n:int) : unit = prim("printNum", n)
+fun (s : string) ^ (s' : string) : string = prim ("concatStringML", (s, s'))
+fun printCharArray (s:chararray) : unit = prim("printStringML", s)
+fun chr (i:int) : char = if i>=0 andalso i<256 then prim ("id", i)
+			 else raise Div
+in
 
-val x = runtime_test0 (1,2,3)
+(* Auto-conversion for type int: convert to uintptr_t *)
+local
+  fun runtime_test0 (a1:int,a2:int,a3:int) : int =
+      prim("@runtime_test0", (a1,a2,a3))
+in
+  val x = 20 + runtime_test0 (1,2,3)
+  val () = printNum x
+end
 
-val () = printNum x
+(* Auto-conversion with boxed int64 arguments (when gc is enabled and unboxed otherwise)
+ * (convert to uintptr_t) *)
+local
+  fun runtime_test0 (a1:int64,a2:int64,a3:int64) : int =
+      prim("@runtime_test0", (a1,a2,a3))
+in
+  val x = 20 + runtime_test0 (1,2,3)
+  val () = printNum x
+  val a1 = 9223372036854775806 + (1:int64)
+  val y = runtime_test0(a1,~1537228672809129301,~28)
+  val () = if y = 4611686018427387764 then print "ok: i64\n" else print "err: i64\n"
+end
+
+(* Auto-conversion with boxed int32 arguments (when gc is enabled and unboxed otherwise)
+ * (convert to uintptr_t) *)
+local
+  fun runtime_test0 (a1:int32,a2:int32,a3:int32) : int =
+      prim("@runtime_test0", (a1,a2,a3))
+in
+  val x = 20 + runtime_test0 (1,2,3)
+  val () = printNum x
+  val a1 = 2000 + (1:int32)
+  val y = runtime_test0(a1,100,10)
+  val () = if y = 2351 then print "ok: i32\n" else print "err: i32\n"
+end
+
+(* Auto-conversion with boxed i64 result (when gc is enabled and unboxed otherwise)
+ * (converts from uintptr_t) *)
+local
+  fun runtime_test0 (a1:int,a2:int,a3:int) : int64 =
+      prim("@runtime_test0", (a1,a2,a3))
+in
+  val x = runtime_test0 (1,2,3)
+  val () = if x = (22:int64) then print "ok: i64\n"
+           else print "err: i64\n"
+  val r = runtime_test0(4611686018427387903,55,10000)
+  val () = if r = (4611686018427438068:int64) then print "ok: i64(2)\n"
+           else print "err: i64(2)\n"
+end
+
+(* Auto-conversion with boxed i32 result (when gc is enabled and unboxed otherwise)
+ * (converts from uintptr_t) *)
+local
+  fun runtime_test0 (a1:int,a2:int,a3:int) : int32 =
+      prim("@runtime_test0", (a1,a2,a3))
+in
+  val x = runtime_test0 (1,2,3)
+  val () = if x = (22:int32) then print "ok: i32 res\n"
+           else print "err: i32 res\n"
+  val r = runtime_test0(1000,100,10)
+  val () = if r = (1350:int32) then print "ok: i32 res2\n"
+           else print "err: i32 res2\n"
+end
+
+(* Auto-conversion with char arrays *)
+local
+  fun alloc0 (n:int) : chararray = prim("allocStringML", n)
+  fun runtime_test_cstring0 (a:chararray,idx:int,c:char) : unit =
+      prim("@runtime_test_cstring0", (a,idx,c))
+  fun app f nil = ()
+    | app f (x::xs) = (f x ; app f xs)
+  fun sub (t:chararray,i:int) : char = prim ("__bytetable_sub", (t,i))
+in
+val a = alloc0 6
+val l = [(0,#"h"), (1,#"e"), (2,#"l"), (3,#"l"), (4,#"o"), (5,chr 0)]
+val () = app (fn (i,c) => runtime_test_cstring0(a,i,c)) l
+
+val () = printCharArray a
+val () = print "\n"
+val () = if sub(a,1) = #"e" then print "ok: chararray\n" else print "err: chararray\n"
+end
+
+end


### PR DESCRIPTION
The MLKit FFI support the notion of _auto-conversion_, which allows for easy integration with c code. Calling a primitive c function

```c
uintptr_t myfun(char* a, uintptr_t x);  
```
can be implemented using auto-conversion from within ML:
```sml
fun mufun(a: CharArray.array, x:Int64.int) : Int64.int = prim("@myfun", (a,x))
```
Depending on whether garbage collection is enabled or not (controlled using the MLKit flag `-no_gc`), `Int64.int` values are either boxed or unboxed (one bit is needed in the case garbage collection is enabled). With auto-conversion, tagging and boxing is done automatically... Notice also that the c function may update entries in the char array and that a safer function would also receive the size of the array as an argument...