### PR TITLE
Remove restrictions on float formatting.

### DIFF
--- a/basis/Real.sml
+++ b/basis/Real.sml
@@ -107,15 +107,15 @@ structure Real : REAL =
           case spec of
               SCI NONE     => to_string_gen "%e" r
             | SCI (SOME n) =>
-                  if n < 0 orelse n > 400 then raise Size
+                  if n < 0 then raise Size
                   else to_string_gen ("%." ^ Int.toString n ^ "e") r
             | FIX NONE     => to_string_gen "%f" r
             | FIX (SOME n) =>
-                  if n < 0 orelse n > 400 then raise Size
+                  if n < 0 then raise Size
                   else to_string_gen ("%." ^ Int.toString n ^ "f") r
             | GEN NONE     => toString r
             | GEN (SOME n) =>
-                  if n < 1 orelse n > 400 then raise Size
+                  if n < 1 then raise Size
                   else mlify (to_string_gen ("%." ^ Int.toString n ^ "g") r)
             | EXACT => fmt (SCI (SOME 30)) r
       end

--- a/src/Runtime/Math.c
+++ b/src/Runtime/Math.c
@@ -892,19 +892,19 @@ REG_POLY_FUN_HDR(stringOfFloat, Region rAddr, size_t arg)
 String
 REG_POLY_FUN_HDR(generalStringOfFloat, Region rAddr, String format, size_t f)
 {
-  char buf[512];
+  size_t size = snprintf(NULL, 0, &(format->data), get_d(f)) + 1;
+  char *buf = malloc(size);
+  snprintf(buf, size, &(format->data), get_d(f));
 
-  /* Unfortunately there seems to be no way to ensure that this does not
-   * crash by overflowing the result_buffer (e.g. when specifying a huge
-   * number of decimal digits in the fixed-point format):
-   */
-  sprintf(buf, &(format->data), get_d(f));
   mkSMLMinus(buf);
+  String s;
   if ( strcmp (buf, "~nan") == 0 ) {
-    return REG_POLY_CALL(convertStringToML,rAddr,"nan");
+    s = REG_POLY_CALL(convertStringToML,rAddr,"nan");
   } else {
-    return REG_POLY_CALL(convertStringToML,rAddr,buf);
+    s = REG_POLY_CALL(convertStringToML,rAddr,buf);
   }
+  free(buf);
+  return s;
 }
 
 /* DEBUG */


### PR DESCRIPTION
According to the Basis, there is no upper limit to the number of digits (although this many is of course absurd in practice).