### PR TITLE
Real cleanup

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 ## MLKit NEWS
 
+* mael 2024-03-04: Various cleanup and fixes. Infinite reals and NaNs
+  may now be parsed as specified in the basis library manual.
+
 ### MLKit version 4.7.8 is released
 
 * mael 2023-12-29: Cleanup and ensurance that mlkit does not write

--- a/basis/Bool.sml
+++ b/basis/Bool.sml
@@ -1,5 +1,5 @@
 (*Bool.sml*)
-   
+
 structure Bool : BOOL =    (* Depends on String and StringCvt *)
   struct
 
@@ -15,21 +15,21 @@ structure Bool : BOOL =    (* Depends on String and StringCvt *)
       let val len = size str
 	  fun toLower c = if #"A" <= c andalso c <= #"Z" then Char.chr (Char.ord c + 32)
 			  else c
-	  fun h i src = if i >= len then SOME src 
-			else case getc src 
+	  fun h i src = if i >= len then SOME src
+			else case getc src
 			       of NONE => NONE
-				| SOME(c, rest) => 
-                                 if  toLower c >= (*#"a"*) String.sub(str,i) then h (i+1) rest
-                                 else NONE
-      in h 0 source 
+				| SOME(c, rest) =>
+                                  if toLower c = String.sub(str,i) then h (i+1) rest
+                                  else NONE
+      in h 0 source
       end
 
     fun scan getc source =
-      let val src = StringCvt.dropl Char.isSpace getc source 
-      in case getstring "true" getc src 
+      let val src = StringCvt.dropl Char.isSpace getc source
+      in case getstring "true" getc src
 	   of SOME rest => SOME(true, rest)
-	    | NONE => 
-	 case getstring "false" getc src 
+	    | NONE =>
+	 case getstring "false" getc src
 	   of SOME rest => SOME(false, rest)
 	    | NONE => NONE
       end
@@ -37,5 +37,3 @@ structure Bool : BOOL =    (* Depends on String and StringCvt *)
     fun fromString s = StringCvt.scanString scan s
 
   end
-
-

--- a/basis/REAL.sig
+++ b/basis/REAL.sig
@@ -347,20 +347,30 @@ by spec.
 format according to the magnitude of r. Equivalent to (fmt (GEN NONE)
 r).
 
-[scan getc charsrc] attempts to scan a floating-point number from the
-character source charsrc, using the accessor getc, and ignoring any
-initial whitespace.  If successful, it returns SOME(r, rest) where r
-is the number scanned, and rest is the unused part of the character
-source. The valid forms of floating-point numerals are described by
+[scan getc strm]
+
+[fromString s]
+
+These functions scan a real value from character source. The first
+version reads from strm using reader getc, ignoring initial
+whitespace. It returns SOME(r,rest) if successful, where r is the
+scanned real value and rest is the unused portion of the character
+stream strm. Values of too large a magnitude are represented as
+infinities; values of too small a magnitude are represented as zeros.
+The second version returns SOME(r) if a real value can be scanned from
+a prefix of s, ignoring any initial whitespace; otherwise, it returns
+NONE. This function is equivalent to StringCvt.scanString scan.
+
+The functions accept real numbers with the following format:
 
 	[+~-]?(([0-9]+(\.[0-9]+)?)|(\.[0-9]+))([eE][+~-]?[0-9]+)?
 
-[fromString s] returns SOME(r) if a floating-point numeral can be
-scanned from a prefix of string s, ignoring any initial whitespace;
-returns NONE otherwise.  The valid forms of floating-point numerals
-are described by
+It also accepts the following string representations of non-finite
+values:
 
-	[+~-]?(([0-9]+(\.[0-9]+)?)|(\.[0-9]+))([eE][+~-]?[0-9]+)?
+        [+~-]?(inf|infinity|nan)
+
+where the alphabetic characters are case-insensitive.
 
 [toDecimal r]
 

--- a/src/Compiler/Lambda/OptLambda.sml
+++ b/src/Compiler/Lambda/OptLambda.sml
@@ -2909,7 +2909,7 @@ structure OptLambda : OPT_LAMBDA =
             else NONE
          end
 
-     (* Given a lambda variable lv and a section sequence 'is=i1..in', see if there are any non-select
+     (* Given a lambda variable lv and an index sequence 'is=i1..in', see if there are any non-select
       * occurences of '#in(..(#i1 lv)..)' in 'exp'; if so, the function is not unboxable,
       * wrt. the particular index sequence 'is' in the argument. *)
 
@@ -3149,7 +3149,7 @@ structure OptLambda : OPT_LAMBDA =
                       | NONE => die "restrict_unbox_fix_env.lv not in env") LvarMap.empty lvars
 
      val layout_unbox_fix_env = LvarMap.layoutMap {start="UnboxFixEnv={",eq="->", sep=", ", finish="}"}
-      (PP.LEAF o Lvars.pr_lvar) layout_fix_boxity
+                                                  (PP.LEAF o Lvars.pr_lvar) layout_fix_boxity
 
      fun lookup env lv = LvarMap.lookup env lv
      fun add_lv (lv,res,env) = LvarMap.add(lv,res,env)

--- a/test/real.sml
+++ b/test/real.sml
@@ -38,6 +38,8 @@ val test2 = tst "test2" (sameSign(~255.0, ~256.0) andalso sameSign(255.0, 256.0)
 val test3 = tst "test3" (sign 1E~300 = 1 andalso sign ~1E~300 = ~1
 			 andalso sign 1E300 = 1 andalso sign ~1E300 = ~1)
 
+val test3a = tst' "test3a" (fn () => (sign (posInf - posInf); false) handle Domain => true | Fail _ => false)
+
 local
     val args = [0.0, 99.0, ~5.0, 1.1, ~1.1, 1.9, ~1.9, 2.5, ~2.5,
 		1000001.4999, ~1000001.4999]
@@ -250,6 +252,18 @@ val test10 =
 	      "~e10", "~E10",
 	      "-e10", "-E10"];
 
+val test10a =
+    tst "test10a" (List.all (fn s => case fromString s of SOME r => isNan r | NONE => false)
+                            ["nan","~nan","-nan","+nan"])
+
+val test10b =
+    tst "test10b" (List.all (fn s => case fromString s of SOME r => not(isNan r) andalso not(isFinite r) andalso not(signBit r) | NONE => false)
+                            ["inf","+inf","infinite","+infinite"])
+
+val test10c =
+    tst "test10c" (List.all (fn s => case fromString s of SOME r => not(isNan r) andalso not(isFinite r) andalso signBit r | NONE => false)
+                            ["-inf","~inf","-infinite","~infinite"])
+
 (* Note: There is some unclarity concerning rounding.  Should 1.45,
 rounded to two significant digits, be "1.4" (nearest even digit) or
 "1.5" (new greater digit) in case of a tie?  PS 1996-05-16 *)
@@ -259,8 +273,8 @@ val test11a =
 		    handle Size => "OK" | _ => "WRONG")
 
 val test11b =
-    tst0 "test11b" ((fmt (StringCvt.FIX (SOME 100000)) 12.3456)
-		    handle Size => "OK" | _ => "WRONG")
+    tst0 "test11b" ((fmt (StringCvt.FIX (SOME 10000)) 12.3456; "OK")
+		    handle Size => "SIZE" | _ => "WRONG")
 
 fun chkFIX (s,r, s0, s1, s2, s6) =
     tst ("chkFIX."^s)(fmt (StringCvt.FIX (SOME 0)) r = s0
@@ -307,8 +321,8 @@ val test12a =
 		    handle Size => "OK" | _ => "WRONG")
 
 val test12b =
-    tst0 "test12b" ((fmt (StringCvt.SCI (SOME 100000)) 12.3456)
-		    handle Size => "OK" | _ => "WRONG")
+    tst0 "test12b" ((fmt (StringCvt.SCI (SOME 10000)) 12.3456; "OK")
+		    handle Size => "SIZE" | _ => "WRONG")
 
 fun chkSCI (r, s0, s1, s2, s6) =
     fmt (StringCvt.SCI (SOME 0)) r = s0
@@ -340,8 +354,8 @@ val test13a =
 		    handle Size => "OK" | _ => "WRONG")
 
 val test13b =
-    tst0 "test13b" ((fmt (StringCvt.GEN (SOME 100000)) 12.3456)
-		    handle Size => "OK" | _ => "WRONG")
+    tst0 "test13b" ((fmt (StringCvt.GEN (SOME 100000)) 12.3456; "OK")
+		    handle Size => "SIZE" | _ => "WRONG")
 
 fun chkGEN (r, s1, s2, s6, s12) =
     fmt (StringCvt.GEN (SOME 1)) r = s1

--- a/test/real.sml.out.ok
+++ b/test/real.sml.out.ok
@@ -2,6 +2,7 @@ Testing structure Real...
 test1    	OK
 test2    	OK
 test3    	OK
+test3a    	OK
 test4a    	OK
 test4b    	OK
 test4c    	OK
@@ -144,6 +145,9 @@ chk2    	OK
 chk2    	OK
 chk2    	OK
 chk2    	OK
+test10a    	OK
+test10b    	OK
+test10c    	OK
 test11a    	OK
 test11b    	OK
 chkFIX.a    	OK


### PR DESCRIPTION
Various cleanup and fixed wrt the `Real` structure:

- `fromString` and `scan` should parse values `nan` and `inf`'s.
- it is ok to use large integers in `SCI`, `FIX`, and `GEN` values (test fixes)...

Fixes #163 