### PR TITLE
Flexible c structs for ML strings and tables

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 ## MLKit NEWS
 
+* mael 2024-03-06: Use C99 flexible C structs for ML strings and
+  tables (internal cleanup).
+
 ### MLKit version 4.7.9 is released
 
 * mael 2024-03-04: Fix issue with Char.isCntrl (issue #162).

--- a/src/Runtime/Dlsym.c
+++ b/src/Runtime/Dlsym.c
@@ -13,7 +13,7 @@
 uintptr_t
 REG_POLY_FUN_HDR(sml_dlopen,uintptr_t pair, Region s, String file1, size_t flags1)
 {
-  char *file = &(file1->data);
+  char *file = file1->data;
   char *c;
   void *p;
   int flags = convertIntToC(flags1);
@@ -21,7 +21,7 @@ REG_POLY_FUN_HDR(sml_dlopen,uintptr_t pair, Region s, String file1, size_t flags
   int use_global = RTLD_LOCAL;
   char *myfile = file;
   if (flags & 0x1) use_lazy = RTLD_LAZY;
-  if (flags & 0x2) use_global = RTLD_GLOBAL; 
+  if (flags & 0x2) use_global = RTLD_GLOBAL;
   if (flags & 0x4) myfile = NULL;
   dlerror();
   p = dlopen(myfile, use_global | use_lazy);
@@ -30,7 +30,7 @@ REG_POLY_FUN_HDR(sml_dlopen,uintptr_t pair, Region s, String file1, size_t flags
   if (c)
   {
     second(pair) = (uintptr_t) REG_POLY_CALL(convertStringToML,s, c);
-  } else 
+  } else
   {
     second(pair) = 0;
   }
@@ -48,32 +48,32 @@ DEFINE_NHASHMAP(dynamic_function_res_map, charhashfunction, mystreq)
 
 static dynamic_function_res_map_hashtable_t *fnmap = NULL;
 
-String 
+String
 REG_POLY_FUN_HDR(resolveFun,Region sAddr, String our_name, String cname, void *libhandle)
 {
   char *c;
   const void *fp = NULL;
   LOCK_LOCK(FUNCTIONTABLEMUTEX);
   if (fnmap == NULL) fnmap = dynamic_function_res_map_new();
-  if (fnmap == NULL) 
+  if (fnmap == NULL)
   {
     LOCK_UNLOCK(FUNCTIONTABLEMUTEX);
     return (String) REG_POLY_CALL(convertStringToML,sAddr, "Allocation Error in __FILE__:__LINE__");
   }
-  if (dynamic_function_res_map_find(fnmap, &(our_name->data), &fp) == hash_DNE)
+  if (dynamic_function_res_map_find(fnmap, our_name->data, &fp) == hash_DNE)
   {
     dlerror();
-    fp = dlsym(libhandle, &(cname->data));
+    fp = dlsym(libhandle, cname->data);
     c = dlerror();
     if (c)
     {
       return (String) REG_POLY_CALL(convertStringToML,sAddr,c);
     }
-    dynamic_function_res_map_update(fnmap, &(our_name->data), fp);
+    dynamic_function_res_map_update(fnmap, our_name->data, fp);
     LOCK_UNLOCK(FUNCTIONTABLEMUTEX);
     return NULL;
   }
-  else 
+  else
   { // hash_OK
     LOCK_UNLOCK(FUNCTIONTABLEMUTEX);
     return (String) REG_POLY_CALL(convertStringToML,sAddr, "Dynamic function already resolved");
@@ -103,13 +103,13 @@ localResolveLibFnAuto(const void **fp, const char *fname)
 {
   const void *myfp = NULL;
   LOCK_LOCK(FUNCTIONTABLEMUTEX);
-  if (fnmap == NULL) return; 
+  if (fnmap == NULL) return;
   if (dynamic_function_res_map_find(fnmap, fname, &myfp) == hash_DNE)
   {
     LOCK_UNLOCK(FUNCTIONTABLEMUTEX);
     return;
   }
-  else 
+  else
   {
     *fp = myfp;
     LOCK_UNLOCK(FUNCTIONTABLEMUTEX);
@@ -122,12 +122,11 @@ localResolveLibFnAuto(const void **fp, const char *fname)
 void
 localResolveLibFnManual(const void **fp, String fname)
 {
-  localResolveLibFnAuto(fp, &(fname->data));
+  localResolveLibFnAuto(fp, fname->data);
 }
 
-String 
+String
 REG_POLY_FUN_HDR(fromCtoMLstring,Region sAddr, char *cs)
 {
   return (String) REG_POLY_CALL(convertStringToML,sAddr,cs);
 }
-

--- a/src/Runtime/Export.c
+++ b/src/Runtime/Export.c
@@ -9,9 +9,9 @@
 
 static int
 charEqual(const char *a, const char *b)
-{ 
+{
     return (strcmp(a,b) ? 0 : 1);
-} 
+}
 
 DECLARE_NHASHMAP(exportmap,void *, char *, const, const)
 DEFINE_NHASHMAP(exportmap,charhashfunction,charEqual)
@@ -24,19 +24,19 @@ sml_regCfuns(String name,void *f)
   const char *e;
   char *e1;
   const void *f1;
-  //  printf("sml_regCfuns %s\n", &(name->data));
-  if (!exportmap) 
+  //  printf("sml_regCfuns %s\n", name->data);
+  if (!exportmap)
   {
     exportmap = exportmap_new();
     if (!exportmap) return;
   }
-  
-  e = &(name->data);
+
+  e = name->data;
   if (exportmap_find(exportmap, e, &f1) == hash_DNE)
   {
     e1 = (char *) malloc(strlen(e) + 1);
     if (!e1) return;
-    strcpy(e1, &(name->data));
+    strcpy(e1, name->data);
     exportmap_insert(exportmap, e1, f);
   }
   return;

--- a/src/Runtime/IO.c
+++ b/src/Runtime/IO.c
@@ -28,7 +28,7 @@ uintptr_t
 openInStream(Context ctx, String path, uintptr_t exn)                    /* SML Basis */
 {
   FILE *fileDesc;
-  if ((fileDesc = fopen(&(path->data), "r")) == NULL)
+  if ((fileDesc = fopen(path->data, "r")) == NULL)
     {
       raise_exn(ctx,exn);
     }
@@ -40,7 +40,7 @@ uintptr_t
 openOutStream(Context ctx, String path, uintptr_t exn)                   /* SML Basis */
 {
   FILE *fileDesc;
-  if ((fileDesc = fopen(&(path->data), "w")) == NULL)
+  if ((fileDesc = fopen(path->data, "w")) == NULL)
     {
       raise_exn(ctx,exn);
     }
@@ -52,7 +52,7 @@ uintptr_t
 openAppendStream(Context ctx, String path, uintptr_t exn)                /* SML Basis */
 {
   FILE *fileDesc;
-  if ((fileDesc = fopen(&(path->data), "a")) == NULL)
+  if ((fileDesc = fopen(path->data, "a")) == NULL)
     {
       raise_exn(ctx,exn);
     }
@@ -64,7 +64,7 @@ uintptr_t
 openInBinStream(Context ctx, String path, uintptr_t exn)                 /* SML Basis */
 {
   FILE *fileDesc;
-  if ((fileDesc = fopen(&(path->data), "rb")) == NULL)
+  if ((fileDesc = fopen(path->data, "rb")) == NULL)
     {
       raise_exn(ctx,exn);
     }
@@ -76,7 +76,7 @@ uintptr_t
 openOutBinStream(Context ctx, String path, uintptr_t exn)                /* SML Basis */
 {
   FILE *fileDesc;
-  if ((fileDesc = fopen(&(path->data), "wb")) == NULL)
+  if ((fileDesc = fopen(path->data, "wb")) == NULL)
     {
       raise_exn(ctx,exn);
     }
@@ -88,7 +88,7 @@ uintptr_t
 openAppendBinStream(Context ctx, String path, uintptr_t exn)             /* SML Basis */
 {
   FILE *fileDesc;
-  if ((fileDesc = fopen(&(path->data), "ab")) == NULL)
+  if ((fileDesc = fopen(path->data, "ab")) == NULL)
     {
       raise_exn(ctx,exn);
     }
@@ -197,7 +197,7 @@ size_t
 outputStream(Context ctx, uintptr_t os1, String s, uintptr_t exn)
 {
   FILE *os = (FILE *)untag_scalar(os1);
-  if ( fputs(&(s->data), os) == EOF )
+  if ( fputs(s->data, os) == EOF )
     {
       fflush(os);
       raise_exn(ctx,exn);
@@ -236,7 +236,7 @@ stdErrStream(uintptr_t dummy)
 void
 sml_chdir(Context ctx, String dirname, uintptr_t exn)              /* SML Basis */
 {
-  if ( chdir(&(dirname->data)) != 0 )
+  if ( chdir(dirname->data) != 0 )
     {
       raise_exn(ctx,exn);
     }
@@ -247,7 +247,7 @@ void
 sml_remove(Context ctx, String name, uintptr_t exn)                /* SML Basis */
 {
   int ret;
-  ret = unlink(&(name->data));
+  ret = unlink(name->data);
   if ( ret != 0 )
     {
       raise_exn(ctx,exn);
@@ -258,7 +258,7 @@ sml_remove(Context ctx, String name, uintptr_t exn)                /* SML Basis 
 void
 sml_rename(Context ctx, String oldname, String newname, uintptr_t exn)    /* SML Basis */
 {
-  if ( rename(&(oldname->data), &(newname->data)) != 0 )
+  if ( rename(oldname->data, newname->data) != 0 )
     {
       raise_exn(ctx,exn);
     }
@@ -277,7 +277,7 @@ sml_access(String path, size_t permarg)               /* ML */
     {
       perms = F_OK;
     }
-  if (access(&(path->data), perms) == 0)
+  if (access(path->data, perms) == 0)
     {
       return mlTRUE;
     }
@@ -302,7 +302,7 @@ size_t
 sml_isdir(Context ctx, String path, uintptr_t exn)             /* SML Basis */
 {
   struct stat buf;
-  if ( stat(&(path->data), &buf) == -1 )
+  if ( stat(path->data, &buf) == -1 )
     {
       raise_exn(ctx,exn);
     }
@@ -316,7 +316,7 @@ sml_isdir(Context ctx, String path, uintptr_t exn)             /* SML Basis */
 void
 sml_mkdir(Context ctx, String path, uintptr_t exn)                        /* SML Basis */
 {
-  if ( mkdir(&(path->data), 0777) == -1 )
+  if ( mkdir(path->data, 0777) == -1 )
     {
       raise_exn(ctx,exn);
     }
@@ -328,7 +328,7 @@ uintptr_t
 sml_modtime(uintptr_t vAddr, Context ctx, String path, uintptr_t exn)             /* SML Basis */
 {
   struct stat buf;
-  if ( stat(&(path->data), &buf) == -1 )
+  if ( stat(path->data, &buf) == -1 )
     {
       raise_exn(ctx,exn);
     }
@@ -340,7 +340,7 @@ sml_modtime(uintptr_t vAddr, Context ctx, String path, uintptr_t exn)           
 void
 sml_rmdir(Context ctx, String path, uintptr_t exn)              /* SML Basis */
 {
-  if ( rmdir(&(path->data)) == -1 )
+  if ( rmdir(path->data) == -1 )
     {
       raise_exn(ctx,exn);
     }
@@ -352,7 +352,7 @@ sml_settime(Context ctx, String path, uintptr_t time, uintptr_t exn)     /* SML 
 {
   struct utimbuf tbuf;
   tbuf.actime = tbuf.modtime = (long)(get_d(time));
-  if ( utime(&(path->data), &tbuf) == -1 )
+  if ( utime(path->data, &tbuf) == -1 )
     {
       raise_exn(ctx,exn);
     }
@@ -363,7 +363,7 @@ size_t
 sml_filesize(Context ctx, String path, uintptr_t exn)              /* SML Basis */
 {
   struct stat buf;
-  if ( stat(&(path->data), &buf) == -1 )
+  if ( stat(path->data, &buf) == -1 )
     {
       raise_exn(ctx,exn);
     }
@@ -374,7 +374,7 @@ uintptr_t
 sml_opendir(Context ctx, String path, uintptr_t exn)           /* SML Basis */
 {
   DIR * dstr;
-  dstr = opendir(&(path->data));
+  dstr = opendir(path->data);
   if ( dstr == NULL )
     {
       raise_exn(ctx,exn);
@@ -447,7 +447,7 @@ size_t
 sml_islink(Context ctx, String path, uintptr_t exn)              /* SML Basis */
 {
   struct stat buf;
-  if (lstat(&(path->data), &buf) == -1)
+  if (lstat(path->data, &buf) == -1)
     {
       raise_exn(ctx,exn);
     }
@@ -489,7 +489,7 @@ REG_POLY_FUN_HDR(sml_readlink, Region rAddr, Context ctx, String path, uintptr_t
 {
   char buffer[MAXPATHLEN];
   long result;
-  result = readlink(&(path->data), buffer, MAXPATHLEN);
+  result = readlink(path->data, buffer, MAXPATHLEN);
   if (result == -1 || result >= MAXPATHLEN)
     {
       raise_exn(ctx,exn);
@@ -505,7 +505,7 @@ REG_POLY_FUN_HDR(sml_realpath, Region rAddr, Context ctx, String path, uintptr_t
 {
   char buffer[MAXPATHLEN];
   char *result;
-  result = realpath(&(path->data), buffer);
+  result = realpath(path->data, buffer);
   if (result == NULL)
     {
       raise_exn(ctx,exn);
@@ -518,7 +518,7 @@ uintptr_t
 sml_devinode(uintptr_t vAddr, Context ctx, String path, uintptr_t exn)             /* SML Basis */
 {
   struct stat buf;
-  if (stat(&(path->data), &buf) == -1)
+  if (stat(path->data, &buf) == -1)
     {
       raise_exn(ctx,exn);
     }
@@ -533,7 +533,7 @@ size_t
 sml_system(String cmd)         /* SML Basis */
 {
   int res;
-  res = system(&(cmd->data));
+  res = system(cmd->data);
   if (res != 0)
     {
       res = -1;
@@ -545,7 +545,7 @@ String
 REG_POLY_FUN_HDR(sml_getenv, Region rAddr, Context ctx, String var, uintptr_t exn)  /* SML Basis */
 {
   char *res;
-  res = (char *)(getenv(&(var->data)));
+  res = (char *)(getenv(var->data));
   if (res == NULL)
     {
       raise_exn(ctx,exn);
@@ -559,7 +559,7 @@ outputBinStream(Context ctx, uintptr_t os1, String s, uintptr_t exn)
   FILE *os = (FILE *) os1;
   strsize = sizeStringDefine(s);
   os = (FILE *)untag_scalar(os);
-  if ( fwrite(&(s->data), 1, strsize, os) != strsize )
+  if ( fwrite(s->data, 1, strsize, os) != strsize )
     {
       fflush(os);
       raise_exn(ctx,exn);

--- a/src/Runtime/Math.c
+++ b/src/Runtime/Math.c
@@ -892,9 +892,9 @@ REG_POLY_FUN_HDR(stringOfFloat, Region rAddr, size_t arg)
 String
 REG_POLY_FUN_HDR(generalStringOfFloat, Region rAddr, String format, size_t f)
 {
-  size_t size = snprintf(NULL, 0, &(format->data), get_d(f)) + 1;
+  size_t size = snprintf(NULL, 0, format->data, get_d(f)) + 1;
   char *buf = malloc(size);
-  snprintf(buf, size, &(format->data), get_d(f));
+  snprintf(buf, size, format->data, get_d(f));
 
   mkSMLMinus(buf);
   String s;
@@ -932,7 +932,7 @@ size_t
 sml_bytes_to_real(size_t d, String s)
 {
   double r;
-  char* a = &(s->data);
+  char* a = s->data;
   r = ((double*)a)[0];
   get_d(d) = r;
   set_dtag(d);

--- a/src/Runtime/Posix.c
+++ b/src/Runtime/Posix.c
@@ -255,7 +255,7 @@ sml_exec (String path, uintptr_t sl, uintptr_t envl, int kind)
   for (i = 0; isCONS(list); list = tl(list), i++)
   {
     elemML = (String) hd(list);
-    args[i] = &(elemML->data);
+    args[i] = elemML->data;
   }
   args[i] = NULL;
 
@@ -274,18 +274,18 @@ sml_exec (String path, uintptr_t sl, uintptr_t envl, int kind)
     for (list = envl, i = 0; isCONS(list); list = tl(list), i++)
     {
       elemML = (String) hd(list);
-      env[i] = &(elemML->data);
+      env[i] = elemML->data;
     }
     env[i] = NULL;
     environ = env;
   }
   if (kind)
   {
-    n = execv(&(path->data), args);
+    n = execv(path->data, args);
   }
   else
   {
-    n = execvp(&(path->data), args);
+    n = execvp(path->data, args);
   }
   return convertIntToML(n);
 }
@@ -356,7 +356,7 @@ REG_POLY_FUN_HDR(sml_readVec,uintptr_t pair, Region sr, int fd, int n1)
       resetRegion(sr);
     }
   s = REG_POLY_CALL(allocStringC, sr, n+1);
-  char *p = &(s->data);
+  char *p = s->data;
   p[n] = '\0';
   r = read(convertIntToC(fd), p, n);
   if (r > 0)
@@ -495,7 +495,7 @@ sml_lstat(uintptr_t pair, String file)
   int res;
   struct stat b;
   mkTagPairML(pair);
-  res = lstat(&(file->data), &b);
+  res = lstat(file->data, &b);
   if (res == -1)
   {
     elemRecordML(pair,0) = convertIntToML(-1);
@@ -510,7 +510,7 @@ sml_stat(uintptr_t pair, String file)
   int res;
   struct stat b;
   mkTagPairML(pair);
-  res = stat(&(file->data), &b);
+  res = stat(file->data, &b);
   if (res == -1)
   {
     elemRecordML(pair,0) = convertIntToML(-1);
@@ -808,7 +808,7 @@ REG_POLY_FUN_HDR(sml_getgrnam, uintptr_t triple, Region memberListR, Region memb
   char *b;
   struct group gbuf, *gbuf2;
   char  **members;
-  char *name = &(nameML->data);
+  char *name = nameML->data;
   mkTagTripleML(triple);
   s = convertIntToC(s) + 1;
   b = (char *) malloc(s);
@@ -888,7 +888,7 @@ REG_POLY_FUN_HDR(sml_getpwnam, long tuple, Region homeR, Region shellR, Context 
   long res;
   char *b;
   struct passwd pbuf, *pbuf2;
-  char *name = &(nameML->data);
+  char *name = nameML->data;
   mkTagRecordML(tuple,5);
   s = convertIntToC(s) + 1;
   b = (char *) malloc(s);

--- a/src/Runtime/Profiling.c
+++ b/src/Runtime/Profiling.c
@@ -337,10 +337,10 @@ ObjectList* lookupObjectListTable(long atId) {
    a tick is made, the time is printed on stdout */
 
 void
-queueMarkProf(StringDesc *str, long pPoint)
+queueMarkProf(String str, long pPoint)
 {
     tellTime = 1;
-    fprintf(stderr,"Reached \"%s\"\n", &(str->data));
+    fprintf(stderr,"Reached \"%s\"\n", str->data);
     return;
 }
 

--- a/src/Runtime/Runtime.c
+++ b/src/Runtime/Runtime.c
@@ -189,13 +189,13 @@ uncaught_exception (Context ctx, String exnStr, unsigned long n, uintptr_t ep)
   ctx->uncaught_exnname = convertIntToC(n);
   fprintf(stderr,"uncaught exception ");
   fflush(stderr);
-  fputs(&(exnStr->data), stderr);
+  fputs(exnStr->data, stderr);
   fflush(stderr);
   if (convertIntToC(n) == failNumber)
   {
     a = second (ep);
     fputs(" ", stderr);
-    fputs(&(((String) a)->data),stderr);
+    fputs(((String) a)->data,stderr);
     fflush(stderr);
   }
   if (convertIntToC(n) == syserrNumber)
@@ -203,7 +203,7 @@ uncaught_exception (Context ctx, String exnStr, unsigned long n, uintptr_t ep)
     a = second(ep);
     a = first(a);
     fputs(" ", stderr);
-    fputs(&(((String) a)->data),stderr);
+    fputs(((String) a)->data,stderr);
     fflush(stderr);
   }
   fprintf(stderr, "\n");
@@ -232,8 +232,8 @@ equalTable(Table x, Table y)
     {
       return mlFALSE;
     }
-  px = &(x->data);
-  py = &(y->data);
+  px = x->data;
+  py = y->data;
   for ( i = 0 ; i < sz_x ; i ++ )
     {
       if ( equalPolyML(*(px+i), *(py+i)) == mlFALSE )

--- a/src/Runtime/Socket.c
+++ b/src/Runtime/Socket.c
@@ -272,7 +272,7 @@ size_t
 sml_sock_sendvec(size_t sock, String s, size_t i, size_t n)
 {
   sml_debug("[sml_sock_sendvec");
-  char *start = (&(s->data)) + convertIntToC(i);
+  char *start = (s->data) + convertIntToC(i);
   int ret = send(convertIntToC(sock), (void*)start, convertIntToC(n), 0);
   sml_debug("]\n");
   return (size_t)convertIntToML(ret);
@@ -328,7 +328,7 @@ sml_sock_bind_unix(size_t sock, String name)
   struct sockaddr_un saddr;
   int size = sizeStringDefine(name) + 1;             // 0-terminated string
   saddr.sun_family = AF_UNIX;
-  bcopy(&(name->data), saddr.sun_path, size);
+  bcopy(name->data, saddr.sun_path, size);
   int ret = bind(convertIntToC(sock),
 		 (struct sockaddr *) &saddr,
 		 size);
@@ -363,7 +363,7 @@ sml_sock_connect_unix(size_t sock, String name)
   struct sockaddr_un saddr;
   int size = sizeStringDefine(name) + 1;             // 0-terminated string
   saddr.sun_family = AF_UNIX;
-  bcopy(&(name->data), saddr.sun_path, size);
+  bcopy(name->data, saddr.sun_path, size);
   int ret = connect(convertIntToC(sock),
 		    (struct sockaddr *) &saddr,
 		    size);
@@ -543,7 +543,7 @@ REG_POLY_FUN_HDR(sml_gethostbyname,
 {
   sml_debug("[sml_gethostbyname");
   sml_gethostby_init(vTup5);
-  struct hostent *host = gethostbyname(&(n->data));
+  struct hostent *host = gethostbyname(n->data);
   if (host == NULL) {
     elemRecordML(vTup5,4) = convertIntToML(-1);
     sml_debug("]*\n");

--- a/src/Runtime/String.c
+++ b/src/Runtime/String.c
@@ -46,7 +46,7 @@ convertStringToC(Context ctx, String mlStr, char *buf, size_t buflen, uintptr_t 
     {
       raise_exn(ctx,exn);
     }
-  for ( p = &(mlStr->data); *p != '\0'; )
+  for ( p = mlStr->data; *p != '\0'; )
     {
       *buf++ = *p++;
     }
@@ -64,7 +64,7 @@ REG_POLY_FUN_HDR(convertStringToML, Region rAddr, const char *cStr)
 
   res = REG_POLY_CALL(allocString, rAddr, strlen(cStr));   // sets size also
 
-  for ( p = &(res->data); *cStr != '\0'; )
+  for ( p = res->data; *cStr != '\0'; )
     {
       *p++ = *cStr++;
     }
@@ -84,7 +84,7 @@ REG_POLY_FUN_HDR(convertBinStringToML, Region rAddr, size_t l, const char *cStr)
   size_t i;
 
   res = REG_POLY_CALL(allocString, rAddr, l);   // sets size also
-  p = &(res->data);
+  p = res->data;
   for (i=0; i<l; i++)
     {
       *p++ = *cStr++;
@@ -137,19 +137,19 @@ REG_POLY_FUN_HDR(concatStringML, Region rAddr, String str1, String str2)
   debug(printf("[enter concatStringML (rAddr=%p,str1=%p,str2=%p)]\n", rAddr,str1,str2);)
   sz = sizeStringDefine(str1) + sizeStringDefine(str2);
   res = REG_POLY_CALL(allocString, rAddr, sz);
-  p = &(res->data);
-  s = &(str1->data);
+  p = res->data;
+  s = str1->data;
   for ( i = 0; i < sizeStringDefine(str1); i++)
     {
       *p++ = *s++;
     }
-  s = &(str2->data);
+  s = str2->data;
   for ( i = 0; i < sizeStringDefine(str2); i++)
     {
       *p++ = *s++;
     }
   *p = '\0';
-/*  printf("\nconcatStringML\n%s\n%s\n  ->  \n%s\n", &(str1->data), &(str2->data), &(res->data));
+/*  printf("\nconcatStringML\n%s\n%s\n  ->  \n%s\n", str1->data, str2->data, res->data);
   printf("length 1: %d, length 2: %d, length 3: %d\n", sizeStringDefine(str1), sizeStringDefine(str2), sizeStringDefine(res)); */
   return res;
 }
@@ -175,7 +175,7 @@ REG_POLY_FUN_HDR(implodeCharsML, Region rAddr, uintptr_t xs)
     }
 
   res = REG_POLY_CALL(allocString, rAddr, length);
-  p = &(res->data);
+  p = res->data;
   for ( ys = xs; isCONS(ys); ys = tl(ys) )
     {
       *p++ = (unsigned char) convertIntToC (hd(ys));
@@ -202,14 +202,14 @@ REG_POLY_FUN_HDR(implodeStringML, Region rAddr, uintptr_t xs)
     }
   res = REG_POLY_CALL(allocString, rAddr, sz);
 
-  p = &(res->data);
+  p = res->data;
   for ( ys = xs; isCONS(ys); ys = tl(ys) )
     {
       String sd;
       size_t i;
       char *s;
       sd = (String)hd(ys);
-      s = &(sd->data);
+      s = sd->data;
       for ( i = 0; i < sizeStringDefine(sd); i++ )
 	{
 	  *p++ = *s++;
@@ -222,7 +222,7 @@ REG_POLY_FUN_HDR(implodeStringML, Region rAddr, uintptr_t xs)
 void
 printStringML(String str)
 {
-  fputs(&(str->data),stdout);
+  fputs(str->data,stdout);
   fflush(stdout);
   return;
 }
@@ -241,8 +241,8 @@ mystrcmp (String s1, String s2)
   if ( l1 < l2 ) min = l1;
   else           min = l2;
 
-  p1 = (unsigned char *) &(s1->data);
-  p2 = (unsigned char *) &(s2->data);
+  p1 = (unsigned char *) s1->data;
+  p2 = (unsigned char *) s2->data;
 
   for ( i = 0; i < min; i++, p1++, p2++ )
     {
@@ -304,7 +304,7 @@ equalStringML(String s1, String s2)
   sz = sizeStringDefine(s1);
   if ( sz != sizeStringDefine(s2) )
     return mlFALSE;
-  for (p1 = &(s1->data), p2 = &(s2->data) ; sz > 0 ; sz-- )
+  for (p1 = s1->data, p2 = s2->data ; sz > 0 ; sz-- )
     if ( *p1++ != *p2++ ) return mlFALSE;
   return mlTRUE;
 }
@@ -322,7 +322,7 @@ REG_POLY_FUN_HDR(exnNameML, Region rAddr, uintptr_t e)
   ml_s = (String)(* ( (*(uintptr_t **)e) + 1));
 #endif
 
-  return REG_POLY_CALL(convertStringToML, rAddr, &(ml_s->data));
+  return REG_POLY_CALL(convertStringToML, rAddr, ml_s->data);
 }
 
 /* explodeStringML(rAddr, str): convert a string to a char list.
@@ -343,7 +343,7 @@ REG_POLY_FUN_HDR(explodeStringML, Region rAddr, String str)
     }
 
    // save first char such that we can return a pointer to it
-  p = &(str->data);
+  p = str->data;
 
 #ifdef PROFILING
   allocPairMLProf(rAddr, pair, pPoint);

--- a/src/Runtime/String.h
+++ b/src/Runtime/String.h
@@ -26,7 +26,7 @@
 
 typedef struct stringDesc {
   size_t size;             // Size of string (tagged)
-  char data;               // C String (null-terminated)
+  char data[];             // C String (null-terminated)
 } StringDesc;
 
 typedef StringDesc* String;

--- a/src/Runtime/Table.c
+++ b/src/Runtime/Table.c
@@ -20,7 +20,7 @@ REG_POLY_FUN_HDR(word_table0, Region rAddr, size_t n)
   {
     size_t *p;
     size_t i;
-    for ( i = 0, p = &(res->data) ; i < n ; i++, p++ )
+    for ( i = 0, p = res->data ; i < n ; i++, p++ )
       {
 	*p = 1;     // scalar value
       }
@@ -47,7 +47,7 @@ REG_POLY_FUN_HDR(word_table_init, Region rAddr, size_t n, size_t x)
   #endif
   res->size = val_tag_table(n);
 
-  p = &(res->data);
+  p = res->data;
   for ( i = 0 ; i < n ; i ++ )
     {
       *p++ = x;

--- a/src/Runtime/Table.h
+++ b/src/Runtime/Table.h
@@ -5,7 +5,7 @@
 
 typedef struct {
   size_t size;     // combined size and tag-field
-  size_t data;     // first element
+  size_t data[];   // first element
 } TableDesc;
 
 typedef TableDesc* Table;

--- a/src/Runtime/Time.c
+++ b/src/Runtime/Time.c
@@ -135,7 +135,7 @@ REG_POLY_FUN_HDR(sml_strftime, Region rAddr, Context ctx, String fmt, uintptr_t 
   tmr.tm_wday = convertIntToC(elemRecordML(v,6));
   tmr.tm_yday = convertIntToC(elemRecordML(v,7));
   tmr.tm_year = convertIntToC(elemRecordML(v,8));
-  ressize = strftime(buf, BUFSIZE, &(fmt->data), &tmr);
+  ressize = strftime(buf, BUFSIZE, fmt->data, &tmr);
   if ( ressize == 0 || ressize == BUFSIZE )
     {
       raise_exn(ctx,exn);

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -1,6 +1,6 @@
 /* src/config.h.in.  Generated from configure.ac by autoheader.  */
 
-/* Define to 1 if you have the <dirent.h> header file, and it defines 'DIR'.
+/* Define to 1 if you have the <dirent.h> header file, and it defines `DIR'.
    */
 #undef HAVE_DIRENT_H
 
@@ -22,7 +22,7 @@
 /* Define to 1 if you have the <malloc.h> header file. */
 #undef HAVE_MALLOC_H
 
-/* Define to 1 if you have the <ndir.h> header file, and it defines 'DIR'. */
+/* Define to 1 if you have the <ndir.h> header file, and it defines `DIR'. */
 #undef HAVE_NDIR_H
 
 /* Define to 1 if you have the <netdb.h> header file. */
@@ -46,14 +46,14 @@
 /* Define to 1 if you have the <string.h> header file. */
 #undef HAVE_STRING_H
 
-/* Define to 1 if you have the <sys/dir.h> header file, and it defines 'DIR'.
+/* Define to 1 if you have the <sys/dir.h> header file, and it defines `DIR'.
    */
 #undef HAVE_SYS_DIR_H
 
 /* Define to 1 if you have the <sys/ioctl.h> header file. */
 #undef HAVE_SYS_IOCTL_H
 
-/* Define to 1 if you have the <sys/ndir.h> header file, and it defines 'DIR'.
+/* Define to 1 if you have the <sys/ndir.h> header file, and it defines `DIR'.
    */
 #undef HAVE_SYS_NDIR_H
 
@@ -102,7 +102,7 @@
 /* Define to the version of this package. */
 #undef PACKAGE_VERSION
 
-/* Define to 1 if all of the C89 standard headers exist (not just the ones
+/* Define to 1 if all of the C90 standard headers exist (not just the ones
    required in a freestanding environment). This macro is provided for
    backward compatibility; new code need not use it. */
 #undef STDC_HEADERS


### PR DESCRIPTION
Use C99 flexible C structs for ML strings and tables (internal cleanup).

This PR eliminates various warnings issued by gcc...