### PR TITLE
fix missing chararray in type environment

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 ## MLKit NEWS
 
+* mael 2026-01-10: Fix bug related to chararray not being present as a type name
+  in the intermediate language type environment during type checking (issue with
+  test of package sml-sha256).
+
 ### MLKit version 4.7.18 is released
 
 * mael 2026-01-09: Distribute binaries built with MLKit to avoid gmp-dependency.

--- a/src/Compiler/CompBasis.sml
+++ b/src/Compiler/CompBasis.sml
@@ -175,7 +175,9 @@ structure CompBasis: COMP_BASIS =
           val tynames = TyName.tyName_LIST :: TyName.tyName_INTINF ::
               TyName.tyName_BOOL ::
               TyName.tyName_FOREIGNPTR ::
-              TyName.tyName_VECTOR :: tynames     (* for elim eq *)
+              TyName.tyName_VECTOR ::     (* for elim eq *)
+              TyName.tyName_CHARARRAY ::  (* for elim eq *)
+              tynames
           val tynames = if quotation() then TyName.tyName_FRAG :: tynames
                         else tynames
           val NEnv1 = Normalize.restrict(NEnv,lvars)


### PR DESCRIPTION
Issue occurs during test of package [sml-sha256](https://github.com/diku-dk/sml-sha256).