### PR TITLE
Save lnkfile also when content is unchanged

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 ## MLKit NEWS
 
+* mael 2026-01-13: Fix issue with unnecessary recompilation due to lnk-file not
+  being written when content is unchanged.
+
 ### MLKit version 4.7.19 is released
 
 * mael 2026-01-10: Fix bug related to chararray not being present as a type name

--- a/src/Manager/Manager.sml
+++ b/src/Manager/Manager.sml
@@ -354,9 +354,9 @@ functor Manager(structure ManagerObjects : MANAGER_OBJECTS
         let val ext = "lnk"
             val p = doPickleGen0 smlfile ModCode.pu ext modc
             val file = targetFromOutput ofile ext
-        in if isFileContentStringBIN file p then ()
-           else writePickle file p
-        end
+        in writePickle file p  (* always write the lnk-file - also if it already contains the data to be written *)
+        end                    (* - it serves as a witness that the underlying target files may have changed due *)
+                               (* to recompilation!                                                              *)
 
     fun readLinkFiles lnkFiles =
         let fun process (nil,hce,modc) = modc

--- a/test/repl/pretty.cmd
+++ b/test/repl/pretty.cmd
@@ -15,4 +15,5 @@ datatype single = Single of int
 val s = Single 322;
 datatype ('a,'b)t = A of 'a * 'b;
 val x = A(4,2.3);
+val r = [{a=true,b=(3,4.3)},{b=(8,2.1),a=false}];
 :quit;

--- a/test/repl/pretty.out.ok
+++ b/test/repl/pretty.out.ok
@@ -25,3 +25,4 @@
 . > datatype ('a, 'b) t
     con A : 'a * 'b -> ('a, 'b) t
 . > val x = A(4,2.3) : (int, real) t
+. > val r = [{a=true,b=(3,4.3)},{a=false,b=(8,2.1)}] : {a: bool, b: int * real} list


### PR DESCRIPTION
Sometimes MLKit recompiles a source file `f` even when `f` has not changed and none of its dependencies have changed. The reason is that by mistake the lnk-file (representing the target code objects for `f`) was not written if the content would not change.