### PR TITLE
Fix layout of LambdaExp string patterns

### DIFF
--- a/src/Compiler/Lambda/LambdaExp.sml
+++ b/src/Compiler/Lambda/LambdaExp.sml
@@ -1017,7 +1017,7 @@ structure LambdaExp : LAMBDA_EXP =
       | SWITCH_W {switch, precision, tyname} =>
           layoutSwitch layoutLambdaExp (fn w => "0x" ^ IntInf.fmt StringCvt.HEX w) switch
       | SWITCH_S sw =>
-          layoutSwitch layoutLambdaExp (fn x => x) sw
+          layoutSwitch layoutLambdaExp (fn x => "\"" ^ String.toString x ^ "\"") sw
       | SWITCH_C sw =>
           let fun unwildify (sw as SWITCH(lamb as VAR{lvar,...},rules,SOME e)) =
                   (case e of

--- a/test/barry/string.out.ok
+++ b/test/barry/string.out.ok
@@ -39,3 +39,4 @@ test22    	OK
 test23    	OK
 test24    	OK
 test25    	OK
+test26    	OK

--- a/test/barry/string.sml
+++ b/test/barry/string.sml
@@ -371,4 +371,11 @@ val test25 =
 		   andalso not (isPrefix "Abcde"  "abcde")
 		   andalso not (isPrefix "abcdE"  "abcde"))
 
+val test26 =
+    tst' "test26" (fn _ =>
+          case "foo" of
+              "bar" => false
+            | "baz" => false
+            | "foo" => true
+            | _ => false)
 end


### PR DESCRIPTION
Barry currently miscompiles code such as

```sml
case s of "this is a string" => true | _ => false
```

into

```sml
case s of this is a string => true | _ => false
```

This PR fixes this, and adds a test case to guard against regressions.